### PR TITLE
Support GTK+ 4.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -206,6 +206,13 @@ CLEANFILES += avahi-ui-gtk3.pc
 endif
 endif
 
+if HAVE_GTK4
+if HAVE_DBUS
+pkgconfig_DATA += avahi-ui-gtk4.pc
+CLEANFILES += avahi-ui-gtk4.pc
+endif
+endif
+
 if HAVE_QT3
 pkgconfig_DATA += avahi-qt3.pc
 CLEANFILES += avahi-qt3.pc

--- a/avahi-discover-standalone/Makefile.am
+++ b/avahi-discover-standalone/Makefile.am
@@ -23,7 +23,7 @@ interfaces = \
 # This cool debug trap works on i386/gcc only
 AM_CFLAGS+='-DDEBUG_TRAP=__asm__("int $$3")'
 
-if HAVE_GTK2OR3
+if HAVE_GTK2OR3OR4
 if HAVE_GLIB
 bin_PROGRAMS = \
 	avahi-discover-standalone
@@ -41,6 +41,12 @@ avahi_discover_standalone_LDADD = \
 	../avahi-glib/libavahi-glib.la \
 	../avahi-core/libavahi-core.la
 
+if HAVE_GTK4
+avahi_discover_standalone_CFLAGS += \
+	$(GLIB30_CFLAGS) $(GTK40_CFLAGS)
+avahi_discover_standalone_LDADD += \
+	$(GLIB30_LIBS) $(GTK40_LIBS)
+else
 if HAVE_GTK3
 avahi_discover_standalone_CFLAGS += \
 	$(GLIB30_CFLAGS) $(GTK30_CFLAGS)
@@ -51,6 +57,7 @@ avahi_discover_standalone_CFLAGS += \
 	$(GLIB20_CFLAGS) $(GTK20_CFLAGS)
 avahi_discover_standalone_LDADD += \
 	$(GLIB20_LIBS) $(GTK20_LIBS)
+endif
 endif
 
 interfaces_DATA = $(interfaces)

--- a/avahi-discover-standalone/main.c
+++ b/avahi-discover-standalone/main.c
@@ -323,7 +323,11 @@ int main(int argc, char *argv[]) {
     gint error;
     AvahiGLibPoll *poll_api;
 
+#if !GTK_CHECK_VERSION (3,89,0)
     gtk_init(&argc, &argv);
+#else
+    gtk_init();
+#endif
 
     avahi_set_allocator(avahi_glib_allocator());
 

--- a/avahi-ui-gtk4.pc.in
+++ b/avahi-ui-gtk4.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=${prefix}/include
+
+Name: avahi-ui
+Description: Avahi Multicast DNS Responder (Common GTK4 UI support)
+Requires: gtk+-4.0 avahi-client avahi-glib
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lavahi-ui-gtk4
+Cflags: -D_REENTRANT -I${includedir}

--- a/avahi-ui/Makefile.am
+++ b/avahi-ui/Makefile.am
@@ -29,7 +29,7 @@ desktop_DATA_in_in = bssh.desktop.in.in bvnc.desktop.in.in
 
 EXTRA_DIST = $(desktop_DATA_in_in)
 
-if HAVE_GTK2OR3
+if HAVE_GTK2OR3OR4
 AM_CFLAGS += -DGNOMELOCALEDIR=\"$(datadir)/locale\"
 if HAVE_DBUS
 if HAVE_GLIB
@@ -51,6 +51,11 @@ lib_LTLIBRARIES += \
 	libavahi-ui-gtk3.la
 endif
 
+if HAVE_GTK4
+lib_LTLIBRARIES += \
+	libavahi-ui-gtk4.la
+endif
+
 libavahi_ui_la_SOURCES = \
 	avahi-ui.h avahi-ui.c
 libavahi_ui_la_CFLAGS = $(AM_CFLAGS) $(GTK20_CFLAGS)
@@ -62,6 +67,11 @@ libavahi_ui_gtk3_la_CFLAGS = $(AM_CFLAGS) $(GTK30_CFLAGS)
 libavahi_ui_gtk3_la_LIBADD = $(AM_LDADD) ../avahi-common/libavahi-common.la ../avahi-client/libavahi-client.la ../avahi-glib/libavahi-glib.la $(GTK30_LIBS)
 libavahi_ui_gtk3_la_LDFLAGS = $(AM_LDFLAGS)  -version-info $(LIBAVAHI_UI_VERSION_INFO)
 
+libavahi_ui_gtk4_la_SOURCES = $(libavahi_ui_la_SOURCES)
+libavahi_ui_gtk4_la_CFLAGS = $(AM_CFLAGS) $(GTK40_CFLAGS)
+libavahi_ui_gtk4_la_LIBADD = $(AM_LDADD) ../avahi-common/libavahi-common.la ../avahi-client/libavahi-client.la ../avahi-glib/libavahi-glib.la $(GTK40_LIBS)
+libavahi_ui_gtk4_la_LDFLAGS = $(AM_LDFLAGS)  -version-info $(LIBAVAHI_UI_VERSION_INFO)
+
 if HAVE_GDBM
 libavahi_ui_la_SOURCES += ../avahi-utils/stdb.h ../avahi-utils/stdb.c
 libavahi_ui_la_CFLAGS += -DDATABASE_FILE=\"$(pkglibdatadir)/service-types.db\"
@@ -69,6 +79,9 @@ libavahi_ui_la_LIBADD += -lgdbm
 
 libavahi_ui_gtk3_la_CFLAGS += -DDATABASE_FILE=\"$(pkglibdatadir)/service-types.db\"
 libavahi_ui_gtk3_la_LIBADD += -lgdbm
+
+libavahi_ui_gtk4_la_CFLAGS += -DDATABASE_FILE=\"$(pkglibdatadir)/service-types.db\"
+libavahi_ui_gtk4_la_LIBADD += -lgdbm
 endif
 
 if HAVE_DBM
@@ -84,12 +97,17 @@ desktop_DATA += bssh.desktop bvnc.desktop
 
 bssh_SOURCES = bssh.c
 
+if HAVE_GTK4
+bssh_CFLAGS = $(AM_CFLAGS) $(GTK40_CFLAGS)
+bssh_LDADD = $(AM_LDADD) $(GTK40_LIBS) ../avahi-client/libavahi-client.la ../avahi-common/libavahi-common.la libavahi-ui-gtk4.la
+else
 if HAVE_GTK3
 bssh_CFLAGS = $(AM_CFLAGS) $(GTK30_CFLAGS)
 bssh_LDADD = $(AM_LDADD) $(GTK30_LIBS) ../avahi-client/libavahi-client.la ../avahi-common/libavahi-common.la libavahi-ui-gtk3.la
 else
 bssh_CFLAGS = $(AM_CFLAGS) $(GTK20_CFLAGS)
 bssh_LDADD = $(AM_LDADD) $(GTK20_LIBS) ../avahi-client/libavahi-client.la ../avahi-common/libavahi-common.la libavahi-ui.la
+endif
 endif
 
 install-exec-local:

--- a/avahi-ui/avahi-ui.c
+++ b/avahi-ui/avahi-ui.c
@@ -1124,7 +1124,12 @@ static void aui_service_dialog_init(AuiServiceDialog *d) {
 
     p->domain_label = gtk_label_new(_("Initializing..."));
     gtk_label_set_ellipsize(GTK_LABEL(p->domain_label), TRUE);
+#if GTK_CHECK_VERSION(3,16,0)
+    gtk_label_set_xalign(GTK_LABEL(p->domain_label), 0);
+    gtk_label_set_yalign(GTK_LABEL(p->domain_label), 0.5);
+#else
     gtk_misc_set_alignment(GTK_MISC(p->domain_label), 0, 0.5);
+#endif
     gtk_box_pack_start(GTK_BOX(vbox), p->domain_label, FALSE, FALSE, 0);
 
 

--- a/avahi-ui/avahi-ui.c
+++ b/avahi-ui/avahi-ui.c
@@ -857,6 +857,7 @@ static void response_callback(GtkDialog *dialog, gint response, gpointer user_da
         GtkTreeIter iter;
         gint interface, protocol;
         gchar *name, *type;
+        GdkWindow *window;
         GdkCursor *cursor;
 
         g_signal_stop_emission(dialog, g_signal_lookup("response", gtk_dialog_get_type()), 0);
@@ -876,8 +877,10 @@ static void response_callback(GtkDialog *dialog, gint response, gpointer user_da
         g_return_if_fail(d->priv->client);
 
         gtk_widget_set_sensitive(GTK_WIDGET(dialog), FALSE);
-        cursor = gdk_cursor_new(GDK_WATCH);
-        gdk_window_set_cursor(gtk_widget_get_window(GTK_WIDGET(dialog)), cursor);
+
+        window = gtk_widget_get_window(GTK_WIDGET(dialog));
+        cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_WATCH);
+        gdk_window_set_cursor(window, cursor);
 #if GTK_CHECK_VERSION(3,0,0)
         g_object_unref(cursor);
 #else

--- a/avahi-ui/avahi-ui.c
+++ b/avahi-ui/avahi-ui.c
@@ -958,6 +958,22 @@ static void set_border_width(GtkContainer *container, gint width) {
 #endif
 }
 
+static void pack_start(GtkBox *box, GtkWidget *child, gboolean expand, gboolean fill) {
+#if GTK_CHECK_VERSION(3,89,0)
+    gtk_box_pack_start(box, child, expand, fill);
+#else
+    gtk_box_pack_start(box, child, expand, fill, 0);
+#endif
+}
+
+static void pack_end(GtkBox *box, GtkWidget *child, gboolean expand, gboolean fill) {
+#if GTK_CHECK_VERSION(3,89,0)
+    gtk_box_pack_end(box, child, expand, fill);
+#else
+    gtk_box_pack_end(box, child, expand, fill, 0);
+#endif
+}
+
 static void domain_button_clicked(GtkButton *button G_GNUC_UNUSED, gpointer user_data) {
     GtkWidget *vbox, *vbox2, *scrolled_window;
     GtkTreeSelection *selection;
@@ -1003,26 +1019,26 @@ static void domain_button_clicked(GtkButton *button G_GNUC_UNUSED, gpointer user
     vbox = gtk_vbox_new(FALSE, 8);
 #endif
     set_border_width(GTK_CONTAINER(vbox), 8);
-    gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(p->domain_dialog))), vbox, TRUE, TRUE, 0);
+    pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(p->domain_dialog))), vbox, TRUE, TRUE);
 
     p->domain_entry = gtk_entry_new();
     gtk_entry_set_max_length(GTK_ENTRY(p->domain_entry), AVAHI_DOMAIN_NAME_MAX);
     gtk_entry_set_text(GTK_ENTRY(p->domain_entry), domain);
     gtk_entry_set_activates_default(GTK_ENTRY(p->domain_entry), TRUE);
     g_signal_connect(p->domain_entry, "changed", G_CALLBACK(domain_entry_changed_callback), d);
-    gtk_box_pack_start(GTK_BOX(vbox), p->domain_entry, FALSE, FALSE, 0);
+    pack_start(GTK_BOX(vbox), p->domain_entry, FALSE, FALSE);
 
 #if GTK_CHECK_VERSION(3,0,0)
     vbox2 = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
 #else
     vbox2 = gtk_vbox_new(FALSE, 8);
 #endif
-    gtk_box_pack_start(GTK_BOX(vbox), vbox2, TRUE, TRUE, 0);
+    pack_start(GTK_BOX(vbox), vbox2, TRUE, TRUE);
 
     scrolled_window = gtk_scrolled_window_new(NULL, NULL);
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW (scrolled_window), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
     gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW (scrolled_window), GTK_SHADOW_ETCHED_IN);
-    gtk_box_pack_start(GTK_BOX(vbox2), scrolled_window, TRUE, TRUE, 0);
+    pack_start(GTK_BOX(vbox2), scrolled_window, TRUE, TRUE);
 
     p->domain_list_store = gtk_list_store_new(N_DOMAIN_COLUMNS, G_TYPE_STRING, G_TYPE_INT);
 
@@ -1044,7 +1060,7 @@ static void domain_button_clicked(GtkButton *button G_GNUC_UNUSED, gpointer user
     p->domain_progress_bar = gtk_progress_bar_new();
     gtk_progress_bar_set_text(GTK_PROGRESS_BAR(p->domain_progress_bar), _("Browsing..."));
     gtk_progress_bar_set_pulse_step(GTK_PROGRESS_BAR(p->domain_progress_bar), 0.1);
-    gtk_box_pack_end(GTK_BOX(vbox2), p->domain_progress_bar, FALSE, FALSE, 0);
+    pack_end(GTK_BOX(vbox2), p->domain_progress_bar, FALSE, FALSE);
 
     gtk_dialog_add_button(GTK_DIALOG(p->domain_dialog), _("_Cancel"), GTK_RESPONSE_CANCEL);
     p->domain_ok_button = GTK_WIDGET(gtk_dialog_add_button(GTK_DIALOG(p->domain_dialog), _("_OK"), GTK_RESPONSE_ACCEPT));
@@ -1131,7 +1147,7 @@ static void aui_service_dialog_init(AuiServiceDialog *d) {
     vbox = gtk_vbox_new(FALSE, 8);
 #endif
     set_border_width(GTK_CONTAINER(vbox), 8);
-    gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(d))), vbox, TRUE, TRUE, 0);
+    pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(d))), vbox, TRUE, TRUE);
 
     p->domain_label = gtk_label_new(_("Initializing..."));
     gtk_label_set_ellipsize(GTK_LABEL(p->domain_label), TRUE);
@@ -1141,7 +1157,7 @@ static void aui_service_dialog_init(AuiServiceDialog *d) {
 #else
     gtk_misc_set_alignment(GTK_MISC(p->domain_label), 0, 0.5);
 #endif
-    gtk_box_pack_start(GTK_BOX(vbox), p->domain_label, FALSE, FALSE, 0);
+    pack_start(GTK_BOX(vbox), p->domain_label, FALSE, FALSE);
 
 
 #if GTK_CHECK_VERSION(3,0,0)
@@ -1149,12 +1165,12 @@ static void aui_service_dialog_init(AuiServiceDialog *d) {
 #else
     vbox2 = gtk_vbox_new(FALSE, 8);
 #endif
-    gtk_box_pack_start(GTK_BOX(vbox), vbox2, TRUE, TRUE, 0);
+    pack_start(GTK_BOX(vbox), vbox2, TRUE, TRUE);
 
     scrolled_window = gtk_scrolled_window_new(NULL, NULL);
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW (scrolled_window), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
     gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW (scrolled_window), GTK_SHADOW_ETCHED_IN);
-    gtk_box_pack_start(GTK_BOX(vbox2), scrolled_window, TRUE, TRUE, 0);
+    pack_start(GTK_BOX(vbox2), scrolled_window, TRUE, TRUE);
 
     p->service_list_store = gtk_list_store_new(N_SERVICE_COLUMNS, G_TYPE_INT, G_TYPE_INT, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING);
 
@@ -1186,7 +1202,7 @@ static void aui_service_dialog_init(AuiServiceDialog *d) {
     p->service_progress_bar = gtk_progress_bar_new();
     gtk_progress_bar_set_text(GTK_PROGRESS_BAR(p->service_progress_bar), _("Browsing..."));
     gtk_progress_bar_set_pulse_step(GTK_PROGRESS_BAR(p->service_progress_bar), 0.1);
-    gtk_box_pack_end(GTK_BOX(vbox2), p->service_progress_bar, FALSE, FALSE, 0);
+    pack_end(GTK_BOX(vbox2), p->service_progress_bar, FALSE, FALSE);
 
     p->domain_button = gtk_button_new_with_mnemonic(_("_Domain..."));
     gtk_button_set_image(GTK_BUTTON(p->domain_button), gtk_image_new_from_icon_name("network-workgroup", GTK_ICON_SIZE_BUTTON));

--- a/avahi-ui/avahi-ui.c
+++ b/avahi-ui/avahi-ui.c
@@ -1072,7 +1072,9 @@ static void domain_button_clicked(GtkButton *button G_GNUC_UNUSED, gpointer user
 
     gtk_window_set_default_size(GTK_WINDOW(p->domain_dialog), 300, 300);
 
+#if !GTK_CHECK_VERSION (3,89,0)
     gtk_widget_show_all(vbox);
+#endif
 
     gtk_list_store_append(p->domain_list_store, &iter);
     gtk_list_store_set(p->domain_list_store, &iter, DOMAIN_COLUMN_NAME, "local", DOMAIN_COLUMN_REF, 1, -1);
@@ -1221,7 +1223,9 @@ static void aui_service_dialog_init(AuiServiceDialog *d) {
 
     gtk_window_set_default_size(GTK_WINDOW(d), 400, 300);
 
+#if !GTK_CHECK_VERSION (3,89,0)
     gtk_widget_show_all(vbox);
+#endif
 
     p->glib_poll = avahi_glib_poll_new(NULL, G_PRIORITY_DEFAULT);
 

--- a/avahi-ui/avahi-ui.c
+++ b/avahi-ui/avahi-ui.c
@@ -1205,7 +1205,9 @@ static void aui_service_dialog_init(AuiServiceDialog *d) {
     pack_end(GTK_BOX(vbox2), p->service_progress_bar, FALSE, FALSE);
 
     p->domain_button = gtk_button_new_with_mnemonic(_("_Domain..."));
+#if !GTK_CHECK_VERSION (3,89,0)
     gtk_button_set_image(GTK_BUTTON(p->domain_button), gtk_image_new_from_icon_name("network-workgroup", GTK_ICON_SIZE_BUTTON));
+#endif
     g_signal_connect(p->domain_button, "clicked", G_CALLBACK(domain_button_clicked), d);
     gtk_dialog_add_action_widget(GTK_DIALOG(d), p->domain_button, GTK_RESPONSE_NONE);
 #if !GTK_CHECK_VERSION (3,12,0)

--- a/avahi-ui/avahi-ui.c
+++ b/avahi-ui/avahi-ui.c
@@ -947,6 +947,17 @@ static void domain_entry_changed_callback(GtkEditable *editable G_GNUC_UNUSED, g
     gtk_widget_set_sensitive(d->priv->domain_ok_button, is_valid_domain_suffix(gtk_entry_get_text(GTK_ENTRY(d->priv->domain_entry))));
 }
 
+static void set_border_width(GtkContainer *container, gint width) {
+#if GTK_CHECK_VERSION(3,89,0)
+    gtk_widget_set_margin_top(GTK_WIDGET(container), width);
+    gtk_widget_set_margin_bottom(GTK_WIDGET(container), width);
+    gtk_widget_set_margin_start(GTK_WIDGET(container), width);
+    gtk_widget_set_margin_end(GTK_WIDGET(container), width);
+#else
+    gtk_container_set_border_width(container, width);
+#endif
+}
+
 static void domain_button_clicked(GtkButton *button G_GNUC_UNUSED, gpointer user_data) {
     GtkWidget *vbox, *vbox2, *scrolled_window;
     GtkTreeSelection *selection;
@@ -980,7 +991,7 @@ static void domain_button_clicked(GtkButton *button G_GNUC_UNUSED, gpointer user
     }
 
     p->domain_dialog = gtk_dialog_new();
-    gtk_container_set_border_width(GTK_CONTAINER(p->domain_dialog), 5);
+    set_border_width(GTK_CONTAINER(p->domain_dialog), 5);
     gtk_window_set_title(GTK_WINDOW(p->domain_dialog), _("Change domain"));
 #if !GTK_CHECK_VERSION(2,21,8)
     gtk_dialog_set_has_separator(GTK_DIALOG(p->domain_dialog), FALSE);
@@ -991,7 +1002,7 @@ static void domain_button_clicked(GtkButton *button G_GNUC_UNUSED, gpointer user
 #else
     vbox = gtk_vbox_new(FALSE, 8);
 #endif
-    gtk_container_set_border_width(GTK_CONTAINER(vbox), 8);
+    set_border_width(GTK_CONTAINER(vbox), 8);
     gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(p->domain_dialog))), vbox, TRUE, TRUE, 0);
 
     p->domain_entry = gtk_entry_new();
@@ -1112,14 +1123,14 @@ static void aui_service_dialog_init(AuiServiceDialog *d) {
     p->service_list_store = p->domain_list_store = NULL;
     p->service_type_names = NULL;
 
-    gtk_container_set_border_width(GTK_CONTAINER(d), 5);
+    set_border_width(GTK_CONTAINER(d), 5);
 
 #if GTK_CHECK_VERSION(3,0,0)
     vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
 #else
     vbox = gtk_vbox_new(FALSE, 8);
 #endif
-    gtk_container_set_border_width(GTK_CONTAINER(vbox), 8);
+    set_border_width(GTK_CONTAINER(vbox), 8);
     gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(d))), vbox, TRUE, TRUE, 0);
 
     p->domain_label = gtk_label_new(_("Initializing..."));

--- a/avahi-ui/bssh.c
+++ b/avahi-ui/bssh.c
@@ -137,7 +137,11 @@ int main(int argc, char*argv[]) {
     bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
     textdomain (GETTEXT_PACKAGE);
 
+#if !GTK_CHECK_VERSION (3,89,0)
     gtk_init(&argc, &argv);
+#else
+    gtk_init();
+#endif
 
     switch (config.command) {
         case COMMAND_HELP:

--- a/configure.ac
+++ b/configure.ac
@@ -565,7 +565,27 @@ if test "x$HAVE_GTK3" = "xyes" ; then
 fi
 AM_CONDITIONAL(HAVE_GTK3, test "x$HAVE_GTK3" = "xyes")
 
-AM_CONDITIONAL(HAVE_GTK2OR3, test "x$HAVE_GTK3" = "xyes" -o "x$HAVE_GTK" = "xyes" )
+#
+# Check for GTK+ 4.0
+#
+AC_ARG_ENABLE(gtk4,
+        AS_HELP_STRING([--disable-gtk4],[Disable use of GTK+ 4]),
+        [case "${enableval}" in
+                yes) HAVE_GTK4=yes ;;
+                no)  HAVE_GTK4=no ;;
+                *) AC_MSG_ERROR(bad value ${enableval} for --enable-gtk4) ;;
+        esac],
+        [HAVE_GTK4=yes])
+
+if test "x$HAVE_GTK4" = "xyes" ; then
+        # Check for GTK 4.0
+        PKG_CHECK_MODULES(GTK40, [ gtk+-4.0 ])
+        AC_SUBST(GTK40_CFLAGS)
+        AC_SUBST(GTK40_LIBS)
+fi
+AM_CONDITIONAL(HAVE_GTK4, test "x$HAVE_GTK4" = "xyes")
+
+AM_CONDITIONAL(HAVE_GTK2OR3OR4, test "x$HAVE_GTK4" = "xyes" -o "x$HAVE_GTK3" = "xyes" -o "x$HAVE_GTK" = "xyes" )
 
 #
 # D-Bus
@@ -1147,6 +1167,7 @@ echo "
     Enable GObject Introspection:              ${found_introspection}
     Enable GTK 2.0:                            ${HAVE_GTK}
     Enable GTK 3.0:                            ${HAVE_GTK3}
+    Enable GTK 4.0:                            ${HAVE_GTK4}
     Enable D-Bus:                              ${HAVE_DBUS}
     With XML:                                  ${with_xml}
     Enable GDBM:                               ${HAVE_GDBM}
@@ -1199,13 +1220,13 @@ if test "x$ENABLE_AUTOIPD" = "xyes" -a "x$HAVE_LIBDAEMON" != "xyes" ; then
    ENABLE_AUTOIPD="no   (You need libdaemon!)"
 fi
 
-HAVE_GTK2OR3=no
-if test "x$HAVE_GTK" = "xyes" -o "x$HAVE_GTK3" = "xyes" ; then
-   HAVE_GTK2OR3=yes
+HAVE_GTK2OR3OR4=no
+if test "x$HAVE_GTK" = "xyes" -o "x$HAVE_GTK3" = "xyes" -o "x$HAVE_GTK4" = "xyes" ; then
+   HAVE_GTK2OR3OR4=yes
 fi
 
 BUILD_UI="no"
-if test "x$HAVE_GTK2OR3" = "xyes" -a "x$BUILD_CLIENT" = "xyes" ; then
+if test "x$HAVE_GTK2OR3OR4" = "xyes" -a "x$BUILD_CLIENT" = "xyes" ; then
    BUILD_UI="yes"
 fi
 
@@ -1223,7 +1244,7 @@ echo "\
     Building avahi-python:              ${BUILD_PYTHON}
     Building libavahi-glib:             ${HAVE_GLIB}
     Building libavahi-gobject:          ${BUILD_GOBJECT}
-    Building avahi-discover-standalone: ${HAVE_GTK2OR3}
+    Building avahi-discover-standalone: ${HAVE_GTK2OR3OR4}
     Building libavahi-qt3:              ${HAVE_QT3}
     Building libavahi-qt4:              ${HAVE_QT4}
     Building avahi-sharp:               ${HAVE_MONO}


### PR DESCRIPTION
These commits first avoid some deprecated API, then add a GTK4 version of avahi-ui, and then make some GTK4-specific changes.

I have not tested this at all and there doesn't seem to be any example/demo code for avahi-ui in the avahi repository itself.