### PR TITLE
autoipd: Don't forget SLEEPING state on conflicting packet

### DIFF
--- a/avahi-autoipd/main.c
+++ b/avahi-autoipd/main.c
@@ -1206,7 +1206,7 @@ static int loop(int iface, uint32_t addr) {
                 retval_sent = 1;
             }
 
-        } else if (event == EVENT_PACKET) {
+        } else if (state != STATE_SLEEPING && event == EVENT_PACKET) {
             ArpPacketInfo info;
 
             assert(in_packet);


### PR DESCRIPTION
If a event type EVENT_PACKET is received and it is determined to be a
conflicting packet the state machine will be kicked into
STATE_WAITING_PROBE.

This is a problem as the autoipd may have been sleeping
(STATE_SLEEPING). This means that despite the presence of a routable
address on the interface autoipd will call its action script.

It seems appropriate that autoipd should only process packets if it is
not sleeping.