### PR TITLE
ci: switch coverage to avahi/avahi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - run: sudo -E .github/workflows/build.sh install-build-deps
       - run: .github/workflows/build.sh build
   coverage:
-    if: github.repository == 'lathiat/avahi'
+    if: github.repository == 'avahi/avahi'
     runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
It's a draft because Coveralls doesn't have access to the repository yet

Depends on https://github.com/avahi/avahi/issues/540