### PR TITLE
ci: switch CIFuzz to avahi/avahi

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
 
     runs-on: ubuntu-22.04
-    if: github.repository == 'lathiat/avahi'
+    if: github.repository == 'avahi/avahi'
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ matrix.architecture }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
It should already work but I'd wait for https://github.com/google/oss-fuzz/pull/11312 to get merged.