### PR TITLE
tree-wide: switch to avahi/avahi

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -90,7 +90,7 @@ case "$1" in
             sed -i "/^\[Service\]/aEnvironment=UBSAN_OPTIONS=$UBSAN_OPTIONS" avahi-daemon/avahi-daemon.service
         fi
 
-        # publish-workstation=yes triggers https://github.com/lathiat/avahi/issues/485
+        # publish-workstation=yes triggers https://github.com/avahi/avahi/issues/485
         # so it isn't set to yes here.
         sed -i '
             s/^#\(add-service-cookie=\).*/\1yes/;

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -42,7 +42,7 @@ systemd-run avahi-browse -varp
 systemd-run avahi-publish -vs test _qotd._tcp 1234 a=1 b
 systemd-run avahi-publish -s --subtype _beep._sub._qotd._tcp BOOP _qotd._tcp 1234
 
-# https://github.com/lathiat/avahi/issues/455
+# https://github.com/avahi/avahi/issues/455
 # The idea is to produce a lot of arguments by splitting the output
 # of the perl one-liner so it shouldn't be quoted.
 # shellcheck disable=SC2046

--- a/po/Makevars
+++ b/po/Makevars
@@ -41,7 +41,7 @@ PACKAGE_GNU = no
 # It can be your email address, or a mailing list address where translators
 # can write to without being subscribed, or the URL of a web page through
 # which the translators can contact you.
-MSGID_BUGS_ADDRESS = https://github.com/lathiat/avahi/issues
+MSGID_BUGS_ADDRESS = https://github.com/avahi/avahi/issues
 
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.

--- a/po/da.po
+++ b/po/da.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Avahi\n"
-"Report-Msgid-Bugs-To: https://github.com/lathiat/avahi/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/avahi/avahi/issues\n"
 "POT-Creation-Date: 2019-02-10 15:24+0000\n"
 "PO-Revision-Date: 2019-02-11 02:31+0000\n"
 "Last-Translator: scootergrisen\n"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Avahi\n"
-"Report-Msgid-Bugs-To: https://github.com/lathiat/avahi/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/avahi/avahi/issues\n"
 "POT-Creation-Date: 2017-05-20 13:03+0000\n"
 "PO-Revision-Date: 2018-08-18 23:50+0200\n"
 "Last-Translator: Mario Blättermann <mario.blaettermann@gmail.com>\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Avahi\n"
-"Report-Msgid-Bugs-To: https://github.com/lathiat/avahi/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/avahi/avahi/issues\n"
 "POT-Creation-Date: 2022-04-02 03:24+0000\n"
 "PO-Revision-Date: 2022-04-26 13:35+0430\n"
 "Last-Translator: Danial Behzadi <dani.behzi@ubuntu.com>\n"

--- a/po/hu.po
+++ b/po/hu.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Avahi\n"
-"Report-Msgid-Bugs-To: https://github.com/lathiat/avahi/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/avahi/avahi/issues\n"
 "POT-Creation-Date: 2019-04-23 12:11+0000\n"
 "PO-Revision-Date: 2019-08-24 23:09+0200\n"
 "Last-Translator: Balázs Úr <ur.balazs at fsf dot hu>\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: https://github.com/lathiat/avahi/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/avahi/avahi/issues\n"
 "POT-Creation-Date: 2022-07-12 03:25+0000\n"
 "PO-Revision-Date: 2022-07-20 15:47+0200\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Avahi\n"
-"Report-Msgid-Bugs-To: https://github.com/lathiat/avahi/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/avahi/avahi/issues\n"
 "POT-Creation-Date: 2016-09-22 02:24+0000\n"
 "PO-Revision-Date: 2016-10-11 16:17+0200\n"
 "Last-Translator: Cédric VALMARY <cvalmary@yahoo.fr>\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: avahi\n"
-"Report-Msgid-Bugs-To: https://github.com/lathiat/avahi/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/avahi/avahi/issues\n"
 "POT-Creation-Date: 2019-02-26 05:06+0000\n"
 "PO-Revision-Date: 2019-02-26 18:00+0100\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Avahi\n"
-"Report-Msgid-Bugs-To: https://github.com/lathiat/avahi/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/avahi/avahi/issues\n"
 "POT-Creation-Date: 2020-07-18 03:24+0000\n"
 "PO-Revision-Date: 2020-07-18 08:50-0300\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"

--- a/po/ro.po
+++ b/po/ro.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Fedora 10\n"
-"Report-Msgid-Bugs-To: https://github.com/lathiat/avahi/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/avahi/avahi/issues\n"
 "POT-Creation-Date: 2020-05-26 15:25+0000\n"
 "PO-Revision-Date: 2021-05-17 18:34+0200\n"
 "Last-Translator: Daniel Șerbănescu <daniel [at] serbanescu [dot] dk>\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Avahi\n"
-"Report-Msgid-Bugs-To: https://github.com/lathiat/avahi/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/avahi/avahi/issues\n"
 "POT-Creation-Date: 2020-05-26 15:25+0000\n"
 "PO-Revision-Date: 2020-09-18 23:36+0200\n"
 "Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Avahi\n"
-"Report-Msgid-Bugs-To: https://github.com/lathiat/avahi/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/avahi/avahi/issues\n"
 "POT-Creation-Date: 2023-10-23 15:24+0000\n"
 "PO-Revision-Date: 2023-10-24 00:58+0300\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"


### PR DESCRIPTION
It's a follow-up to 94e1ffdfbe7a1b7036b9902bab15ea0ef8b24eb4

The coverage job can't be switched. It's tracked separately in https://github.com/avahi/avahi/pull/537.