### PR TITLE
Expand supported qtypes with some new types

### DIFF
--- a/avahi-common/defs.h
+++ b/avahi-common/defs.h
@@ -324,7 +324,12 @@ typedef enum {
 
 /** @{ \name DNS RR definitions */
 
-/** DNS record types, see RFC 1035 */
+/** DNS record types, see RFC 1035.
+ *
+ * types registry:
+ * https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
+ * Any new types should be added to avahi_dns_type_to_string function.
+ */
 enum {
     AVAHI_DNS_TYPE_A = 0x01,
     AVAHI_DNS_TYPE_NS = 0x02,
@@ -335,7 +340,27 @@ enum {
     AVAHI_DNS_TYPE_MX = 0x0F,
     AVAHI_DNS_TYPE_TXT = 0x10,
     AVAHI_DNS_TYPE_AAAA = 0x1C,
-    AVAHI_DNS_TYPE_SRV = 0x21
+    AVAHI_DNS_TYPE_SRV = 0x21,
+    /* following types do not implement avahi_record_to_string yet. */
+    AVAHI_DNS_TYPE_NAPTR = 0x23,
+    AVAHI_DNS_TYPE_CERT = 0x25,
+    AVAHI_DNS_TYPE_DNAME = 0x27,
+    AVAHI_DNS_TYPE_OPT = 0x29,     /**< EDNS0 option (41) */
+    AVAHI_DNS_TYPE_SSHFP = 0x2c,
+    AVAHI_DNS_TYPE_NSEC = 0x2f,
+    AVAHI_DNS_TYPE_TLSA = 0x34,
+    AVAHI_DNS_TYPE_OPEPGPKEY = 0x3d,
+    AVAHI_DNS_TYPE_SVCB = 0x40,
+    AVAHI_DNS_TYPE_HTTPS = 0x41,
+    /* DNS specific record types, see RFC 1035 */
+    AVAHI_DNS_TYPE_TKEY = 0xf9, /* 249 */
+    AVAHI_DNS_TYPE_TSIG = 0xfa, /* 250 */
+    AVAHI_DNS_TYPE_IXFR = 0xfb, /* 251 */
+    AVAHI_DNS_TYPE_AXFR = 0xfc, /* 252 */
+    AVAHI_DNS_TYPE_ANY = 0xff, /**< Special query type for requesting all records, "*" */
+    AVAHI_DNS_TYPE_URI = 0x100,
+    AVAHI_DNS_TYPE_CAA = 0x101,
+    AVAHI_DNS_TYPE_RESINFO = 0x105,
 };
 
 /** DNS record classes, see RFC 1035 */

--- a/avahi-core/rr.c
+++ b/avahi-core/rr.c
@@ -197,6 +197,9 @@ const char *avahi_dns_class_to_string(uint16_t class) {
     }
 }
 
+/* selected record types from registry:
+ * https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
+ */
 const char *avahi_dns_type_to_string(uint16_t type) {
     switch (type) {
         case AVAHI_DNS_TYPE_CNAME:
@@ -213,12 +216,37 @@ const char *avahi_dns_type_to_string(uint16_t type) {
             return "TXT";
         case AVAHI_DNS_TYPE_SRV:
             return "SRV";
-        case AVAHI_DNS_TYPE_ANY:
-            return "ANY";
         case AVAHI_DNS_TYPE_SOA:
             return "SOA";
         case AVAHI_DNS_TYPE_NS:
             return "NS";
+        /* TODO: implement avahi_record_to_string for following types */
+        case AVAHI_DNS_TYPE_NAPTR:
+            return "NAPTR";
+        case AVAHI_DNS_TYPE_CERT:
+            return "CERT";
+        case AVAHI_DNS_TYPE_DNAME:
+            return "DNAME";
+        case AVAHI_DNS_TYPE_SSHFP:
+            return "SSHFP";
+        case AVAHI_DNS_TYPE_NSEC:
+            return "NSEC";
+        case AVAHI_DNS_TYPE_TLSA:
+            return "TLSA";
+        case AVAHI_DNS_TYPE_OPEPGPKEY:
+            return "OPENPGPKEY";
+        case AVAHI_DNS_TYPE_SVCB:
+            return "SVCB";
+        case AVAHI_DNS_TYPE_HTTPS:
+            return "HTTPS";
+        case AVAHI_DNS_TYPE_ANY:
+            return "ANY";
+        case AVAHI_DNS_TYPE_URI:
+            return "URI";
+        case AVAHI_DNS_TYPE_CAA:
+            return "CAA";
+        case AVAHI_DNS_TYPE_RESINFO:
+            return "RESINFO";
         default:
             return NULL;
     }

--- a/avahi-core/rr.h
+++ b/avahi-core/rr.h
@@ -31,16 +31,6 @@
 
 AVAHI_C_DECL_BEGIN
 
-/** DNS record types, see RFC 1035, in addition to those defined in defs.h */
-enum {
-    AVAHI_DNS_TYPE_ANY = 0xFF,   /**< Special query type for requesting all records */
-    AVAHI_DNS_TYPE_OPT = 41,     /**< EDNS0 option */
-    AVAHI_DNS_TYPE_TKEY = 249,
-    AVAHI_DNS_TYPE_TSIG = 250,
-    AVAHI_DNS_TYPE_IXFR = 251,
-    AVAHI_DNS_TYPE_AXFR = 252
-};
-
 /** DNS record classes, see RFC 1035, in addition to those defined in defs.h */
 enum {
     AVAHI_DNS_CLASS_ANY = 0xFF,         /**< Special query type for requesting all records */


### PR DESCRIPTION
Apple devices have been seen to use HTTPS RR queries even on mDNS. Define that record type to ensure it would be printed nicely in logs.