### PR TITLE
CI: always look for ASan/UBSan reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Repository checkout
         uses: actions/checkout@v4
       - run: sudo -E .github/workflows/build.sh install-build-deps
-      - run: .github/workflows/build.sh build
+      - run: sudo -E .github/workflows/build.sh build
   coverage:
     if: github.repository == 'lathiat/avahi'
     runs-on: ubuntu-22.04
@@ -48,7 +48,7 @@ jobs:
       - name: Repository checkout
         uses: actions/checkout@v4
       - run: sudo -E .github/workflows/build.sh install-build-deps
-      - run: .github/workflows/build.sh build
+      - run: sudo -E .github/workflows/build.sh build
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -3,23 +3,6 @@
 set -eux
 set -o pipefail
 
-look_for_asan_ubsan_reports() {
-    journalctl --sync
-    set +o pipefail
-    pids="$(
-        journalctl -b -u avahi-daemon --grep 'SUMMARY: .*Sanitizer:' |
-        sed -r -n 's/.* .+\[([0-9]+)\]: SUMMARY:.*/\1/p'
-    )"
-    set -o pipefail
-
-    if [[ -n "$pids" ]]; then
-        for pid in $pids; do
-           journalctl -b _PID="$pid" --no-pager
-        done
-        return 1
-    fi
-}
-
 run() {
     if ! "$@"; then
         journalctl --sync
@@ -99,5 +82,3 @@ if systemctl is-failed avahi-daemon; then
     journalctl -u avahi-daemon --no-pager
     exit 1
 fi
-
-look_for_asan_ubsan_reports


### PR DESCRIPTION
When avahi-daemon fails under ASan/UBSan the tests trying to reach it via D-Bus start to fail too with cryptic error messages and without ASan reports it's hard to tell what exactly fails.

This patch is prompted by https://github.com/avahi/avahi/pull/551 where the smoke test failed with
```
** (process:23892): WARNING **: 10:26:43.529: Error initializing Avahi: Daemon not running
glib-integration: client.c:626: void avahi_client_free(AvahiClient *): Assertion `client' failed.
```
without any way to figure out what went wrong.

With this patch applied the following backtrace would have been shown:
```
avahi-daemon[23694]: browse.c: Found CNAME loop on interface 2, proto 1, query cname0.local        IN        AAAA
avahi-daemon[23694]: browse.c: Found CNAME loop on interface 2, proto 1, query cname0.local        IN        AAAA
avahi-daemon[23694]: =================================================================
avahi-daemon[23694]: ==23694==ERROR: AddressSanitizer: heap-use-after-free on address 0x60b000000f70 at pc 0x7f5aac154542 bp 0x7ffe59141be0 sp 0x7ffe59141bd8
avahi-daemon[23694]: READ of size 4 at 0x60b000000f70 thread T0
avahi-daemon[23694]:     #0 0x7f5aac154541 in lookup_multicast_callback /home/runner/work/avahi/avahi/avahi-core/browse.c:268:12
avahi-daemon[23694]:     #1 0x7f5aac1bfa0a in avahi_multicast_lookup_engine_notify /home/runner/work/avahi/avahi/avahi-core/multicast-lookup.c:317:21
avahi-daemon[23694]:     #2 0x7f5aac115808 in avahi_cache_update /home/runner/work/avahi/avahi/avahi-core/cache.c:363:13
avahi-daemon[23694]:     #3 0x7f5aac0e9621 in handle_response_packet /home/runner/work/avahi/avahi/avahi-core/server.c:720:21
avahi-daemon[23694]:     #4 0x7f5aac0e3cf6 in dispatch_packet /home/runner/work/avahi/avahi/avahi-core/server.c:1032:9
avahi-daemon[23694]:     #5 0x7f5aac0e2116 in mcast_socket_event /home/runner/work/avahi/avahi/avahi-core/server.c:1093:13
avahi-daemon[23694]:     #6 0x7f5aac464b6c in avahi_simple_poll_dispatch /home/runner/work/avahi/avahi/avahi-common/simple-watch.c:585:13
avahi-daemon[23694]:     #7 0x7f5aac4651a8 in avahi_simple_poll_iterate /home/runner/work/avahi/avahi/avahi-common/simple-watch.c:605:14
avahi-daemon[23694]:     #8 0x5592a3ed3884 in run_server /home/runner/work/avahi/avahi/avahi-daemon/main.c:1279:18
avahi-daemon[23694]:     #9 0x5592a3ec4132 in main /home/runner/work/avahi/avahi/avahi-daemon/main.c:1708:13
avahi-daemon[23694]:     #10 0x7f5aabc29d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
avahi-daemon[23694]:     #11 0x7f5aabc29e3f in __libc_start_main csu/../csu/libc-start.c:392:3
avahi-daemon[23694]:     #12 0x5592a3e05054 in _start (/usr/sbin/avahi-daemon+0x71054) (BuildId: 0aa9e5ea43ef010d5f42e9109eabd1434ff1b3db)
...
```

It was tested in https://github.com/evverx/avahi/actions/runs/7678776722