### PR TITLE
Update description for enable-wide-area to mention impact for avahi-resolve-address

### DIFF
--- a/man/avahi-daemon.conf.5.xml.in
+++ b/man/avahi-daemon.conf.5.xml.in
@@ -201,10 +201,13 @@
       ("yes" or "no"). Enable wide-area DNS-SD, aka
       DNS-SD over unicast DNS. If this is enabled only domains
       ending in .local will be resolved on mDNS, all other domains
-      are resolved via unicast DNS. If you want to maintain multiple
-      different multicast DNS domains even with this option enabled
-      we encourage you to use subdomains of .local, such as
-      "kitchen.local". This option defaults to "no".</p>
+      are resolved via unicast DNS. When this is enabled, unless
+      explicitly specified reverse lookups will go over unicast DNS
+      and fall back to mDNS if unicast DNS lookups fails.
+      If you want to maintain multiple different multicast DNS
+      domains even with this option enabled we encourage you to
+      use subdomains of .local, such as "kitchen.local".
+      This option defaults to "no".</p>
     </option>
 
   </section>

--- a/man/avahi-resolve.1.xml.in
+++ b/man/avahi-resolve.1.xml.in
@@ -37,9 +37,12 @@
 	<options>
 
       <p>When passing -n, specify one or more fully qualified mDNS/DNS host name(s)
-      (e.g. "foo.local") to resolve into IP addresses on the
-      command line. When passing -a, specify one or more IP address
-      to resolve into host names.</p>
+      (e.g. "foo.local") to resolve into IP addresses on the command line.</p>
+
+      <p>When passing -a, specify one or more IP addresses
+      to resolve into host names. When <opt>enable-wide-area</opt> is
+      set to yes in <manref name="avahi-daemon.conf" section="5"/>,
+      reverse lookups will go over unicast DNS first and fallback to mDNS.</p>
 
       <p>avahi-resolve-host-name is equivalent to avahi-resolve --name.</p>
 


### PR DESCRIPTION
Current description for enable-wide-area=yes doesn't mention the impact for reverse lookup, it caused me sometime to figure out the impact, update the description to explicitly mention that enable-wide-area=yes also cause reverse lookup to use unicast DNS.