### PR TITLE
fuzz: make the build script compatible with aarch64 

### DIFF
--- a/fuzz/fuzz-strlst.c
+++ b/fuzz/fuzz-strlst.c
@@ -23,16 +23,21 @@
 
 #include "avahi-common/malloc.h"
 #include "avahi-common/strlst.h"
+#include "avahi-common/utf8.h"
 
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     AvahiStringList *a = NULL, *b = NULL;
     uint8_t *rdata = NULL;
+    char *t = NULL;
     size_t s, n;
     int ret;
 
     if (avahi_string_list_parse(data, size, &a) < 0)
         goto finish;
+
+    if ((t = avahi_string_list_to_string(a)))
+        assert(avahi_utf8_valid(t));
 
     avahi_free(avahi_string_list_to_string(a));
     avahi_string_list_get_service_cookie(a);
@@ -59,6 +64,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     assert(ret);
 
 finish:
+    avahi_free(t);
     avahi_free(rdata);
     if (b)
         avahi_string_list_free(b);

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -44,13 +44,25 @@ mkdir -p "$OUT"
 
 export LIB_FUZZING_ENGINE=${LIB_FUZZING_ENGINE:--fsanitize=fuzzer}
 
+if [[ -n "$FUZZING_ENGINE" ]]; then
+    apt-get update
+    apt-get install -y autoconf gettext libtool m4 automake pkg-config libexpat-dev
+
+    if [[ "$ARCHITECTURE" == i386 ]]; then
+        apt-get install -y libexpat-dev:i386
+    fi
+fi
+
 sed -i 's/check_inconsistencies=yes/check_inconsistencies=no/' common/acx_pthread.m4
 
-./autogen.sh \
+if ! ./autogen.sh \
     --disable-stack-protector --disable-qt3 --disable-qt4 --disable-qt5 --disable-gtk \
     --disable-gtk3 --disable-dbus --disable-gdbm --disable-libdaemon --disable-python \
     --disable-manpages --disable-mono --disable-monodoc --disable-glib --disable-gobject \
-    --disable-libevent --disable-libsystemd
+    --disable-libevent --disable-libsystemd; then
+    cat config.log
+    exit 1
+fi
 
 make -j"$(nproc)" V=1
 


### PR DESCRIPTION
OSS-Fuzz doesn't fully support aarch64 yet
https://github.com/google/oss-fuzz/issues/8164 but the toolchain already
provides an easy way to build and run the fuzz targets on aarch64 with
```
./infra/helper.py ... --architecture=aarch64 ...
```
This patch prevents avahi from failing to compile there by avoiding
installing the "386" dependencies when they aren't necessary. All the
build dependencies are brought upstream to make it possible to change
them upstream without having to send patches to OSS-Fuzz.

The script also dumps build logs when configure fails to make it
easier to debug build failures.

The strlist fuzz target was updated to make sure "printable" DNS-SD key/value pairs are UTF-8.

Those strings are consumed in various places and it's generally expected
that they are UTF-8. It's prompted by an issue where python scripts
threw the UnicodeDecodeError exception trying to parse the output of
avahi-browse -arp.

The fuzz target fails on architectures where char is unsigned (like
aarch64 for example):
```
fuzz-strlst: fuzz/fuzz-strlst.c:40: int LLVMFuzzerTestOneInput(const uint8_t *, size_t): Assertion `avahi_utf8_valid(t)' failed.
==26== ERROR: libFuzzer: deadly signal
    #0 0x4a38f8 in __sanitizer_print_stack_trace /src/llvm-project/compiler-rt/lib/ubsan/ubsan_diag_standalone.cpp:31:3
    #1 0x44d350 in fuzzer::PrintStackTrace() cxa_noexception.cpp
    #2 0x436728 in fuzzer::Fuzzer::CrashCallback() cxa_noexception.cpp
    #3 0x5500834ffc  (/usr/lib/aarch64-linux-gnu/ld-2.31.so+0x23ffc)
    #4 0x550099cd74 in raise (/lib/aarch64-linux-gnu/libc.so.6+0x33d74)
    #5 0x5500989aa8 in abort (/lib/aarch64-linux-gnu/libc.so.6+0x20aa8)
    #6 0x550099648c  (/lib/aarch64-linux-gnu/libc.so.6+0x2d48c)
    #7 0x55009964f0 in __assert_fail (/lib/aarch64-linux-gnu/libc.so.6+0x2d4f0)
    #8 0x4a4e70 in LLVMFuzzerTestOneInput /src/avahi/fuzz/fuzz-strlst.c:40:9
``

but it shouldn't break anything because currently it's run on x86_64/i386
only on a regular basis. It should help to catch bugs/regressions
though.
