### PR TITLE
docs: add links to coverity, oss-fuzz, coverage and codespell reports

### DIFF
--- a/README
+++ b/README
@@ -17,6 +17,18 @@ GIT:
 MAILING LIST:
 	https://lists.freedesktop.org/mailman/listinfo/avahi
 
+COVERITY SCAN REPORT:
+	https://scan.coverity.com/projects/avahi-daemon
+
+OSS-FUZZ REPORT:
+	https://introspector.oss-fuzz.com/project-profile?project=avahi
+
+COVERAGE REPORT:
+	https://coveralls.io/github/avahi/avahi
+
+CODESPELL REPORT:
+	https://fossies.org/linux/test/avahi-master.tar.gz/codespell.html
+
 AUTHORS:
 	Lennart Poettering
 	Trent Lloyd

--- a/docs/NEWS
+++ b/docs/NEWS
@@ -58,7 +58,7 @@ This is because the D-Bus implementation in some languages would only bind to
 signals of an object after it was created and had received the new object's
 path. This led to such languages missing the initial results sent between the
 time the object was created and it had setup a filter to receive it's signals.
-This primarily occured in languages that create dynamic bindings for D-Bus
+This primarily occurred in languages that create dynamic bindings for D-Bus
 objects using introspection such as Python. The avahi-client C api was not
 affected as it globally binds to all avahi signals without specifying
 individual object paths and still makes use of the V1 API.
@@ -71,7 +71,7 @@ The old org.freedesktop.Avahi.Server interface is still supported and there is
 no intention to remove this API. Additionally this problem has also been solved
 for old clients by adding a very small 10ms delay before we start sending
 results to give the client time to bind to the signals which should silently
-fix the issue in most cases without introducing a noticable or impactful delay.
+fix the issue in most cases without introducing a noticeable or impactful delay.
 
 Clients implementing the new org.freedesktop.Avahi.Server2 D-Bus interface will
 not work with older Avahi daemons. It is suggested that clients may wish to
@@ -848,7 +848,7 @@ Avahi 0.5.2
 ===========
 
  * Bug fix release.
- * Fix browing in QT applications (was totally broken)
+ * Fix browsing in QT applications (was totally broken)
  * Minor documentation update.
 
 Avahi 0.5.1
@@ -881,7 +881,7 @@ Avahi 0.4, the 'Hyvää päivää' release
  * Fix a critical bug in avahi-daemon triggered by configuring an interface
    with various DHCP clients when you have no other active addresses which
    caused avahi-daemon to abort.
- * Move to using python-gdbm exclusivly for the service type database.
+ * Move to using python-gdbm exclusively for the service type database.
  * Add support for SUSE
  * Various fixes to the build system
 

--- a/docs/README
+++ b/docs/README
@@ -10,17 +10,7 @@ Avahi has a mailing list:
 
 You have a chance to meet the developers on
 
-	#avahi on irc.freenode.org
-
-Please report bugs to the freedesktop.org bugzilla:
-
-	http://bugs.freedesktop.org/
-
-Avahi's SVN repository is freely accessible:
-
-	svn checkout svn://svn.0pointer.de/avahi/trunk avahi
-
-	http://0pointer.de/cgi-bin/viewcvs.cgi/?root=avahi
+	#avahi on irc.libera.chat
 
 Avahi has the following requirements:
 	- glib2
@@ -30,7 +20,7 @@ Avahi has the following requirements:
 	- DBUS 0.3x (optional, if you disable this, the daemon is not
 	  accessible over IPC to other applications!)
 	- gtk2 + glade (optional, needed for avahi-discover-standalone)
-	- doxygen (optional, needed for the API documentaton)
+	- doxygen (optional, needed for the API documentation)
 	- Python 2.4, pygtk2 (optional, needed by all client tools)
 	- python-twisted (optional, needed by avahi-bookmarks)
     - xmltoman (if building from SVN rather than a tarball)

--- a/docs/TODO
+++ b/docs/TODO
@@ -48,7 +48,7 @@ done:
 * check: TC bit is valid for queries ONLY
 * add SRV and TXT records referenced from PTR records automatically to packet
 * add A and AAAA records referenced from SRV records automatically to packet
-* support known answer suppresion for incoming unicast queries
+* support known answer suppression for incoming unicast queries
 * check whether RRsets are supported correctly (i.e. that all records of an
   RRset are really sent if it is requested) (rfc 2181)
 * case insensitive comparison

--- a/man/avahi-daemon.conf.5.xml.in
+++ b/man/avahi-daemon.conf.5.xml.in
@@ -203,7 +203,7 @@
       ending in .local will be resolved on mDNS, all other domains
       are resolved via unicast DNS. When this is enabled, unless
       explicitly specified reverse lookups will go over unicast DNS
-      and fall back to mDNS if unicast DNS lookups fails.
+      and fall back to mDNS if unicast DNS lookups fail.
       If you want to maintain multiple different multicast DNS
       domains even with this option enabled we encourage you to
       use subdomains of .local, such as "kitchen.local".


### PR DESCRIPTION
to make it easier to find them.

The second commit removes obsolete content from docs/README. It was extracted from https://github.com/avahi/avahi/pull/481.