### PR TITLE
smoke-test: pass overly long hostname to RESOLVE-HOSTNAME

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -78,6 +78,8 @@ should_fail dbus_call ResolveHostName "iisiu" -1 -1 one.one.one.one -1 2
 dbus_call ResolveService "iisssiu" -1 -1 "$(hostname)" _ssh._tcp local -1 0
 should_fail dbus_call ResolveService "iisssiu" -1 -1 "$(hostname)" _ssh._tcp dns-sd.org -1 2
 
+printf "%s\n" "RESOLVE-ADDRESS $(perl -e 'print q/A/ x 1014')" | ncat -w1 -U /run/avahi-daemon/socket
+
 cmds=(
     "HELP"
     "RESOLVE-HOSTNAME $h"


### PR DESCRIPTION
and add it to the corpus used by radamsa too.