### PR TITLE
fuzz: turn on pointer-overflow and alignment checks 

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -78,6 +78,12 @@ should_fail dbus_call ResolveHostName "iisiu" -1 -1 one.one.one.one -1 2
 dbus_call ResolveService "iisssiu" -1 -1 "$(hostname)" _ssh._tcp local -1 0
 should_fail dbus_call ResolveService "iisssiu" -1 -1 "$(hostname)" _ssh._tcp dns-sd.org -1 2
 
+# https://github.com/avahi/avahi/issues/491
+dbus_call GetAlternativeHostName "s" "a-2147483647"
+
+# https://github.com/avahi/avahi/issues/526
+dbus_call GetAlternativeServiceName "s" "a #2147483647"
+
 printf "%s\n" "RESOLVE-ADDRESS $(perl -e 'print q/A/ x 1014')" | ncat -w1 -U /run/avahi-daemon/socket
 
 cmds=(

--- a/avahi-common/alternative.c
+++ b/avahi-common/alternative.c
@@ -21,6 +21,7 @@
 #include <config.h>
 #endif
 
+#include <limits.h>
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -81,7 +82,11 @@ char *avahi_alternative_host_name(const char *s) {
         char *c, *m;
         int n;
 
-        n = atoi(e)+1;
+        n = atoi(e);
+        if (n == INT_MAX)
+            n = 1;
+        else
+            n++;
         if (!(m = avahi_strdup_printf("%i", n)))
             return NULL;
 
@@ -156,7 +161,11 @@ char *avahi_alternative_service_name(const char *s) {
         size_t l;
         int n;
 
-        n = atoi(e)+1;
+        n = atoi(e);
+        if (n == INT_MAX)
+            n = 1;
+        else
+            n++;
         if (!(m = avahi_strdup_printf("%i", n)))
             return NULL;
 

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -51,6 +51,13 @@ if [[ -n "$FUZZING_ENGINE" ]]; then
     if [[ "$ARCHITECTURE" == i386 ]]; then
         apt-get install -y libexpat-dev:i386
     fi
+
+    if [[ "$SANITIZER" == undefined ]]; then
+        additional_ubsan_checks=pointer-overflow,alignment
+        UBSAN_FLAGS="-fsanitize=$additional_ubsan_checks -fno-sanitize-recover=$additional_ubsan_checks"
+        CFLAGS="$CFLAGS $UBSAN_FLAGS"
+        CXXFLAGS="$CXXFLAGS $UBSAN_FLAGS"
+    fi
 fi
 
 sed -i 's/check_inconsistencies=yes/check_inconsistencies=no/' common/acx_pthread.m4


### PR DESCRIPTION
* common: fix int overflow in avahi_alternative_*_name (extracted from https://github.com/avahi/avahi/pull/547)
* smoke-test: poke GetAlternative*Name