### PR TITLE
libdns_sd: Use allocator with memory set to zero

### DIFF
--- a/avahi-compat-libdns_sd/compat.c
+++ b/avahi-compat-libdns_sd/compat.c
@@ -366,7 +366,7 @@ static DNSServiceRef sdref_new(void) {
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, fd) < 0)
         goto fail;
 
-    if (!(sdref = avahi_new(struct _DNSServiceRef_t, 1)))
+    if (!(sdref = avahi_new0(struct _DNSServiceRef_t, 1)))
         goto fail;
 
     sdref->n_ref = 1;


### PR DESCRIPTION
Fixes segfault on shutdown. On client failure, generic_client_callback function simply checks if all the callback functions are non-zero and triggers the callback. This change sets the callback function memory to NULL and prevents the application from thinking that a callback has been installed.