### PR TITLE
avahi-core/entry.c: Allow localhost as valid hostname

### DIFF
--- a/avahi-core/entry.c
+++ b/avahi-core/entry.c
@@ -598,7 +598,7 @@ static int server_add_service_strlst_nocopy(
     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, avahi_is_valid_service_name(name), AVAHI_ERR_INVALID_SERVICE_NAME);
     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, avahi_is_valid_service_type_strict(type), AVAHI_ERR_INVALID_SERVICE_TYPE);
     AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, !domain || avahi_is_valid_domain_name(domain), AVAHI_ERR_INVALID_DOMAIN_NAME);
-    AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, !host || avahi_is_valid_fqdn(host), AVAHI_ERR_INVALID_HOST_NAME);
+    AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL(s, !host || avahi_is_valid_fqdn(host) || !strcmp(host, "localhost"), AVAHI_ERR_INVALID_HOST_NAME);
 
     if (!domain)
         domain = s->domain_name;


### PR DESCRIPTION
Several daemons (PAPPL based printer applications, ipp-usb) register/can register services only locally to prevent remote access to the service due security reasons (using mDNS gives them unified API for autodiscovery, local machine and network), so it would be great if avahi supported localhost as valid hostname.

Currently, if daemon wants to register service locally, it cannot pass localhost as registering hostname - Avahi returns it as invalid hostname until the machine's hostname is renamed to localhost (which is sometimes unwanted). The fix is to allow localhost in the check `AVAHI_CHECK_VALIDITY_SET_RET_GOTO_FAIL` when checking hostname.