### PR TITLE
avahi-daemon.conf: turn off wide-area

### DIFF
--- a/avahi-daemon/avahi-daemon.conf
+++ b/avahi-daemon/avahi-daemon.conf
@@ -39,7 +39,7 @@ ratelimit-interval-usec=1000000
 ratelimit-burst=1000
 
 [wide-area]
-enable-wide-area=yes
+#enable-wide-area=no
 
 [publish]
 #disable-publishing=no


### PR DESCRIPTION
In its current form it doesn't interact with mDNS well. For example services advertised over mDNS where PTR RRs point "_services._dns-sd._udp.local" to unresolvable wide-area domain names bring down mDNS browsers. DNS isn't supported well either. For example responses larger than 512 bytes aren't supported, all the queries come from the same UDP port and so on. All in all in its current form it isn't something that should be enabled by default or picked up accidentally by packages downstream.

It reverts the part of 2c453196ee040e17e357f3431b0647391c88d616 where that feature was turned on.