### PR TITLE
man: be more specific about host-name-from-machine-id

### DIFF
--- a/avahi-daemon/avahi-daemon.conf
+++ b/avahi-daemon/avahi-daemon.conf
@@ -20,6 +20,7 @@
 
 [server]
 #host-name=foo
+#host-name-from-machine-id=no
 #domain-name=local
 #browse-domains=0pointer.de, zeroconf.org
 use-ipv4=yes

--- a/man/avahi-daemon.conf.5.xml.in
+++ b/man/avahi-daemon.conf.5.xml.in
@@ -41,8 +41,11 @@
 
     <option>
       <p><opt>host-name-from-machine-id=</opt> Takes a boolean
-      value ("yes" or "no"). If set to "yes" avahi-daemon
-      will use the machine-id as name on the LAN.</p>
+      value ("yes" or "no"). If set to "yes" avahi-daemon will use the
+      <manref name="machine-id" section="5"/>
+      as name on the LAN. It should be noted that this ID
+      uniquely identifies the host. It should be considered "confidential",
+      and must not be exposed in untrusted environments. Defaults to "no".</p>
     </option>
 
     <option>


### PR DESCRIPTION
Ideally this knob should be revisited but given that it was introduced more than 10 years ago it is probably already used in its current form and can't be changed without breaking something somewhere.

It's a follow-up to 147cdce70b22ae7cee9fb4fe123db40952f31c9e

Closes https://github.com/avahi/avahi/issues/365