### PR TITLE
core: reject more service names violating RFC6763

### DIFF
--- a/avahi-common/domain-test.c
+++ b/avahi-common/domain-test.c
@@ -134,6 +134,12 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     assert(!avahi_is_valid_fqdn("::1"));
     assert(!avahi_is_valid_fqdn(".192.168.50.1."));
 
+    res = avahi_service_name_split("_ssh._tcp.local", name, sizeof(name), type, sizeof(type), domain, sizeof(domain));
+    assert(res < 0);
+
+    res = avahi_service_name_split("_services._dns-sd._udp.local", NULL, 0, type, sizeof(type), domain, sizeof(domain));
+    assert(res < 0);
+
     res = avahi_service_name_split("test._ssh._tcp.local", name, sizeof(name), type, sizeof(type), domain, sizeof(domain));
     assert(res >= 0);
     assert(strcmp(name, "test") == 0);

--- a/avahi-common/domain.c
+++ b/avahi-common/domain.c
@@ -578,7 +578,7 @@ int avahi_service_name_split(const char *p, char *name, size_t name_size, char *
     if ((oname && !avahi_is_valid_service_name(oname)))
         return AVAHI_ERR_INVALID_SERVICE_NAME;
 
-    if (!avahi_is_valid_service_type_generic(otype))
+    if (!avahi_is_valid_service_type_strict(otype) && !avahi_is_valid_service_subtype(otype))
         return AVAHI_ERR_INVALID_SERVICE_TYPE;
 
     if (!avahi_is_valid_domain_name(odomain))

--- a/avahi-core/browse-service-type.c
+++ b/avahi-core/browse-service-type.c
@@ -69,6 +69,11 @@ static void record_browser_callback(
             return;
         }
 
+        if (!avahi_is_valid_service_type_strict(type)) {
+            avahi_log_debug("Invalid service '%s'", record->data.ptr.name);
+            return;
+        }
+
         b->callback(b, interface, protocol, event, type, domain, flags, b->userdata);
     } else
         b->callback(b, interface, protocol, event, NULL, b->domain_name, flags, b->userdata);

--- a/avahi-core/browse-service.c
+++ b/avahi-core/browse-service.c
@@ -73,6 +73,11 @@ static void record_browser_callback(
             return;
         }
 
+        if (!avahi_is_valid_service_type_strict(type)) {
+            avahi_log_debug("Invalid service '%s'", record->data.ptr.name);
+            return;
+        }
+
         b->callback(b, interface, protocol, event, service, type, domain, flags, b->userdata);
 
     } else


### PR DESCRIPTION
Accodring to https://datatracker.ietf.org/doc/html/rfc6763#section-9
```
A DNS query for
   PTR records with the name "_services._dns-sd._udp.<Domain>" yields a
   set of PTR records, where the rdata of each PTR record is the two-
   label <Service> name, plus the same domain, e.g.,
   "_http._tcp.<Domain>".
```
and according to https://datatracker.ietf.org/doc/html/rfc6763#section-7
```
The <Service> portion of a Service Instance Name consists of a pair
   of DNS labels, following the convention already established for SRV
   records [RFC2782].
```

With this patch applied avahi rejects service names violating those
rules. It prevents avahi-browse from showing one-label service names and
also prevents avahi-discover-standalone from crashing on receiving
announcements with non-compliant PTR resource records.

In the case of
avahi-discover-standalone it was technically a DoS allowing packets
with unsolicited announcements containing non-compliant service names to
crash it. In practice it was triggered by a VM running Home Assistant OS
and sending announcements with PTR resource records pointing
`_services._dns-sd._udp.local` to `_services._dns-sd._udp.local`.

Closes https://github.com/avahi/avahi/issues/581