### PR TITLE
avahi-browse: make -t/-c work when goodbye packets are received before resolvers fail/time out

### DIFF
--- a/avahi-utils/avahi-browse.c
+++ b/avahi-utils/avahi-browse.c
@@ -284,8 +284,10 @@ static void remove_service(Config *c, ServiceInfo *i) {
 
     AVAHI_LLIST_REMOVE(ServiceInfo, info, services, i);
 
-    if (i->resolver)
+    if (i->resolver) {
         avahi_service_resolver_free(i->resolver);
+        n_resolving--;
+    }
 
     avahi_free(i->name);
     avahi_free(i->type);
@@ -331,6 +333,7 @@ static void service_browser_callback(
                 return;
 
             remove_service(c, info);
+            check_terminate(c);
 
             print_service_line(c, '-', interface, protocol, name, type, domain, 1);
             break;


### PR DESCRIPTION
Related to https://github.com/avahi/avahi/issues/264

This PR addresses one particular scenario. There can be other scenarios preventing avahi-browse from stopping:
https://github.com/avahi/avahi/issues/444#issuecomment-2019121991 but they should be identified and fixed one by one.