### PR TITLE
CI: lint GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           - { CC: "gcc", DISTCHECK: "true", VALGRIND: "true" }
           - { CC: "gcc", ASAN_UBSAN: "true" }
-          - { CC: "clang" }
+          - { CC: "clang", ASAN_UBSAN: "false" }
           - { CC: "clang", ASAN_UBSAN: "true" }
     env: ${{ matrix.env }}
     steps:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,31 @@
+---
+name: Super-Linter
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Lint GH Actions
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Lint
+        uses: super-linter/super-linter/slim@v6.3.0
+        env:
+          MULTI_STATUS: false
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_GITHUB_ACTIONS: true


### PR DESCRIPTION
with https://github.com/rhysd/actionlint?tab=readme-ov-file#actionlint to make it easier to add/change/review GH Actions.

Mostly in preparation for an action sending data to Coverity Scan.

Related to https://github.com/avahi/avahi/issues/540