### PR TITLE
avahi-discover: Fix invalid escape sequences

### DIFF
--- a/avahi-python/avahi/ServiceTypeDatabase.py.in
+++ b/avahi-python/avahi/ServiceTypeDatabase.py.in
@@ -95,9 +95,9 @@ class ServiceTypeDatabase:
     def __iter__(self):
 
         def want_key(key):
-            if not re.search('_[a-zA-Z0-9-]+\\._[a-zA-Z0-9-]+', key):
+            if not re.search(r'_[a-zA-Z0-9-]+\._[a-zA-Z0-9-]+', key):
                 return False
-            if re.search('_[a-zA-Z0-9-]+\\._[a-zA-Z0-9-]+\\[.*\\]', key):
+            if re.search(r'_[a-zA-Z0-9-]+\._[a-zA-Z0-9-]+\[.*\]', key):
                 return False
             return True
 

--- a/avahi-python/avahi/ServiceTypeDatabase.py.in
+++ b/avahi-python/avahi/ServiceTypeDatabase.py.in
@@ -95,9 +95,9 @@ class ServiceTypeDatabase:
     def __iter__(self):
 
         def want_key(key):
-            if not re.search('_[a-zA-Z0-9-]+\._[a-zA-Z0-9-]+', key):
+            if not re.search('_[a-zA-Z0-9-]+\\._[a-zA-Z0-9-]+', key):
                 return False
-            if re.search('_[a-zA-Z0-9-]+\._[a-zA-Z0-9-]+\[.*\]', key):
+            if re.search('_[a-zA-Z0-9-]+\\._[a-zA-Z0-9-]+\\[.*\\]', key):
                 return False
             return True
 


### PR DESCRIPTION
Corrects 
```python
/usr/lib/python3.12/site-packages/avahi/ServiceTypeDatabase.py:98: SyntaxWarning: invalid escape sequence '\.'
  if not re.search('_[a-zA-Z0-9-]+\._[a-zA-Z0-9-]+', key):
```