### PR TITLE
Add dbus-1 to avahi-client Requires.private

### DIFF
--- a/avahi-client.pc.in
+++ b/avahi-client.pc.in
@@ -8,3 +8,4 @@ Description: Avahi Multicast DNS Responder (Client Support)
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lavahi-common -lavahi-client
 Cflags: -D_REENTRANT -I${includedir}
+Requires.private: dbus-1


### PR DESCRIPTION
This fixes static linking of avahi-client using pkg-config, by telling pkg-config to also link with dbus, since static libraries don't carry their own dependency information.