### PR TITLE
ci: forward Coverity Scan notifications to COVERITY_SCAN_NOTIFICATION_EMAIL

### DIFF
--- a/.github/workflows/coverity.sh
+++ b/.github/workflows/coverity.sh
@@ -41,13 +41,12 @@ function coverity_install_script {
 }
 
 function run_coverity {
-    local results_dir tool_dir results_archive sha author_email response status_code
+    local results_dir tool_dir results_archive sha response status_code
 
     results_dir="cov-int"
     tool_dir=$(find "$COVERITY_SCAN_TOOL_BASE" -type d -name 'cov-analysis*')
     results_archive="analysis-results.tgz"
     sha=$(git rev-parse --short HEAD)
-    author_email=$(git log -1 --pretty="%aE")
 
     ./bootstrap.sh --enable-compat-howl --enable-compat-libdns_sd --enable-tests \
         --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
@@ -62,7 +61,7 @@ function run_coverity {
                --silent --write-out "\n%{http_code}\n" \
                --form project="$COVERITY_SCAN_PROJECT_NAME" \
                --form token="$COVERITY_SCAN_TOKEN" \
-               --form email="$author_email" \
+               --form email="$COVERITY_SCAN_NOTIFICATION_EMAIL" \
                --form file="@$results_archive" \
                --form version="$sha" \
                --form description="Daily build" \

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -23,4 +23,5 @@ jobs:
       - name: Run Coverity
         env:
           COVERITY_SCAN_TOKEN: "${{ secrets.COVERITY_SCAN_TOKEN }}"
+          COVERITY_SCAN_NOTIFICATION_EMAIL: "${{ secrets.COVERITY_SCAN_NOTIFICATION_EMAIL }}"
         run: .github/workflows/coverity.sh


### PR DESCRIPTION
to prevent it from sending notifications to the authors of the latest commits.

That logic came from some internal script and doesn't make sense upstream.

The idea was borrowed from https://github.com/bus1/dbus-broker/pull/363