### PR TITLE
ci: fuzz ini parser

### DIFF
--- a/fuzz/fuzz-ini-file-parser.c
+++ b/fuzz/fuzz-ini-file-parser.c
@@ -1,0 +1,79 @@
+/***
+  This file is part of avahi.
+
+  avahi is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) any later version.
+
+  avahi is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+  Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with avahi; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  USA.
+***/
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "avahi-common/malloc.h"
+#include "avahi-core/log.h"
+#include "avahi-daemon/ini-file-parser.h"
+
+void log_function(AvahiLogLevel level, const char *txt) {}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char name[] = "/tmp/fuzz-ini-file-parser.XXXXXX";
+    int fd = -1;
+    ssize_t n;
+    AvahiIniFile *f;
+    AvahiIniFileGroup *g;
+
+    fd = mkstemp(name);
+    assert(fd >= 0);
+
+    n = write(fd, data, size);
+    assert(n == (ssize_t) size);
+
+    close(fd);
+
+    avahi_set_log_function(log_function);
+
+    if (!(f = avahi_ini_file_load(name)))
+        goto cleanup;
+
+    avahi_log_info("%u groups\n", f->n_groups);
+
+    for (g = f->groups; g; g = g->groups_next) {
+        AvahiIniFilePair *p;
+        avahi_log_info("<%s> (%u pairs)\n", g->name, g->n_pairs);
+
+        for (p = g->pairs; p; p = p->pairs_next) {
+            char **split, **i;
+
+            avahi_log_info("\t<%s> = ", p->key);
+            split = avahi_split_csv(p->value);
+
+            for (i = split; *i; i++)
+                avahi_log_info("<%s> ", *i);
+
+            avahi_strfreev(split);
+
+            avahi_log_info("\n");
+        }
+    }
+
+cleanup:
+    if (f)
+        avahi_ini_file_free(f);
+    unlink(name);
+
+    return 0;
+}

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -75,6 +75,7 @@ make -j"$(nproc)" V=1
 
 for f in fuzz/fuzz-*.c; do
     fuzz_target=$(basename "$f" .c)
+    additional_obj_files=
 
     # CFLAGS have to be split
     # shellcheck disable=SC2086
@@ -82,12 +83,20 @@ for f in fuzz/fuzz-*.c; do
         "fuzz/$fuzz_target.c" \
         -o "$fuzz_target.o"
 
+    if [[ "$fuzz_target" == "fuzz-ini-file-parser" ]]; then
+        # CFLAGS have to be split
+        # shellcheck disable=SC2086
+        $CC -c $CFLAGS -I. avahi-daemon/ini-file-parser.c -o ini-file-parser.o
+        additional_obj_files+=" ini-file-parser.o"
+    fi
+
     # CXXFLAGS have to be split
     # shellcheck disable=SC2086
     $CXX $CXXFLAGS \
         "$fuzz_target.o" \
         -o "$OUT/$fuzz_target" \
         $LIB_FUZZING_ENGINE \
+        $additional_obj_files \
         "avahi-core/.libs/libavahi-core.a" "avahi-common/.libs/libavahi-common.a"
 done
 

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -44,7 +44,7 @@ mkdir -p "$OUT"
 
 export LIB_FUZZING_ENGINE=${LIB_FUZZING_ENGINE:--fsanitize=fuzzer}
 
-if [[ -n "$FUZZING_ENGINE" ]]; then
+if [[ -n "${FUZZING_ENGINE:-}" ]]; then
     apt-get update
     apt-get install -y autoconf gettext libtool m4 automake pkg-config libexpat-dev
 


### PR DESCRIPTION
and also prevent bash from complaining about unbound FUZZING_ENGINE variable.

Fixes:
```
+ mkdir -p /home/vagrant/avahi/out
+ export LIB_FUZZING_ENGINE=-fsanitize=fuzzer
+ LIB_FUZZING_ENGINE=-fsanitize=fuzzer
./fuzz/oss-fuzz.sh: line 47: FUZZING_ENGINE: unbound variable
```
It's a follow-up to d2aac837a47ea180e5b5a77c568841d77e92b57e