### PR TITLE
docs: modernize INSTALL

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Reporting Security Issues
+
+To report a security issue, please use the ["Report a Vulnerability"](https://github.com/avahi/avahi/security/advisories/new) tab.

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -78,8 +78,17 @@ case "$1" in
         fi
         export CXXFLAGS="$CFLAGS"
 
-        ./bootstrap.sh --enable-compat-howl --enable-compat-libdns_sd --enable-tests \
-            --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
+        ./bootstrap.sh \
+            --enable-compat-howl \
+            --enable-compat-libdns_sd \
+            --enable-core-docs \
+            --enable-tests \
+            --libdir="/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+            --localstatedir=/var \
+            --prefix=/usr \
+            --runstatedir=/run \
+            --sysconfdir=/etc
+
         make -j"$(nproc)" V=1
 
         if [[ "$BUILD_ONLY" == true ]]; then

--- a/docs/INSTALL
+++ b/docs/INSTALL
@@ -4,50 +4,41 @@ While "configure" and "make" may be run as normal user all other commands
 need to be run as root.
 
 Configure the build system:
-	$ ./configure --sysconfdir=/etc --localstatedir=/var
+	$ autoreconf -if
+	$ ./configure \
+            --libdir="/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+            --localstatedir=/var \
+            --prefix=/usr \
+            --runstatedir=/run \
+            --sysconfdir=/etc
 
-Some configure options available:
+It should be noted that it's suitable for testing purposes only.
+The script configuring the actual Debian package can be found at
+https://salsa.debian.org/utopia-team/avahi/-/blob/debian/master/debian/rules?ref_type=heads.
+Among other things it also turns on the hardening flags described at
+https://wiki.debian.org/Hardening.
 
-    --disable-gtk            disable GTK+ tools                (default: enabled)
-    --disable-dbus           disable DBUS support              (default: enabled)
-    --disable-python         disable building python modules   (default: enabled)
-    --with-dbus-sys=<dir>    where D-BUS system.d directory is
-    --with-distro=<distro>   the target Linux distribution (one of redhat,
-                                    suse, gentoo, debian or slackware)
-    --with-avahi-user=<user> User for running the Avahi daemon (avahi)
-    --with-avahi-group=<grp> Group for Avahi (avahi)
-
-    Please note that by disabling DBUS you lose the ability to publish and browse
-    services from local applications.
-
-    Please note that Avahi currently ships with a init scripts for only a few
-    distributions. if yours is not supported right now, YMMV. Patches welcome.
-
+Build and install avahi:
 	$ make
 	# make install
 	# ldconfig
 
-Add a user an a group for avahi. (Debian specific)
+Add a user and a group for avahi. (Debian specific)
 	# addgroup --system avahi
 	# adduser --system --no-create-home --ingroup avahi avahi
 
-Ask DBUS to re-read its policies:
-	# kill -HUP `cat /var/run/dbus/pid`
+Ask D-Bus to re-read its policies:
+	# systemctl reload dbus
 
 Now start the Avahi daemon:
-	# /etc/init.d/avahi-daemon start
+	# systemctl start avahi-daemon
 
 Optionally start the unicast DNS configuration daemon:
-	# /etc/init.d/avahi-dnsconfd start
+	# systemctl start avahi-dnsconfd
 
 To start the two daemons at boot time on Debian based distributions:
-	with DBUS support:
-	# ln -s /etc/init.d/avahi-daemon /etc/dbus-1/event.d/75avahi-daemon
-	# ln -s /etc/init.d/avahi-dnsconfd /etc/dbus-1/event.d/76avahi-dnsconfd
-
-	without DBUS support:
-	# update-rc.d avahi-daemon defaults 25 15
-	# update-rc.d avahi-dnsconfd defaults 26 14
+	# systemctl enable avahi-daemon
+	# systemctl enable avahi-dnsconfd
 
 If you plan to use avahi-autoipd you have to create the user/group
 "avahi-autoipd" much the same way as "avahi".


### PR DESCRIPTION
to make it actually work on Debian/Ubuntu. Other topics like turning
off D-Bus or running it on non-systemd systems should probably be
documented elsewhere eventually too.

The CI script is updated too to make sure the configure options
mentioned in INSTALL keep working on Ubuntu.

Addresses https://github.com/avahi/avahi/issues/612

and add SECURITY.md pointing to the "Report a vulnerability" tab. People reporting
vulnerabilities are usually aware of that GitHub feature but it
shouldn't hurt to mention it explicitly. It's also shown
when issues are opened.