### PR TITLE
README: point to the Fedora Weblate instance

### DIFF
--- a/README
+++ b/README
@@ -29,6 +29,9 @@ COVERAGE REPORT:
 CODESPELL REPORT:
 	https://fossies.org/linux/test/avahi-master.tar.gz/codespell.html
 
+TRANSLATION PLATFORM:
+	https://translate.fedoraproject.org/engage/avahi
+
 AUTHORS:
 	Lennart Poettering
 	Trent Lloyd


### PR DESCRIPTION
to make it easier to find it.

It's a follow-up to 45378fb97eff8bc4d2b43c471fb10410cb1b7073