### PR TITLE
Fix conditional typo on client-publish-service.c

### DIFF
--- a/examples/client-publish-service.c
+++ b/examples/client-publish-service.c
@@ -132,7 +132,7 @@ static void create_services(AvahiClient *c) {
         }
 
         /* Add an additional (hypothetic) subtype */
-        if ((ret = avahi_entry_group_add_service_subtype(group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0, name, "_printer._tcp", NULL, "_magic._sub._printer._tcp") < 0)) {
+        if ((ret = avahi_entry_group_add_service_subtype(group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0, name, "_printer._tcp", NULL, "_magic._sub._printer._tcp")) < 0) {
             fprintf(stderr, "Failed to add subtype _magic._sub._printer._tcp: %s\n", avahi_strerror(ret));
             goto fail;
         }

--- a/examples/core-publish-service.c
+++ b/examples/core-publish-service.c
@@ -112,7 +112,7 @@ static void create_services(AvahiServer *s) {
     }
 
     /* Add an additional (hypothetic) subtype */
-    if ((ret = avahi_server_add_service_subtype(s, group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0, name, "_printer._tcp", NULL, "_magic._sub._printer._tcp") < 0)) {
+    if ((ret = avahi_server_add_service_subtype(s, group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, 0, name, "_printer._tcp", NULL, "_magic._sub._printer._tcp")) < 0) {
         fprintf(stderr, "Failed to add subtype _magic._sub._printer._tcp: %s\n", avahi_strerror(ret));
         goto fail;
     }


### PR DESCRIPTION
A badly placed closing bracket was assigning a comparison to the ret value, instead of the real returned value. The conditional still worked this way, but the fprintf message would be wrong as the strerror value "ret" would always be 1, and not the real returned value.