### PR TITLE
Enable style checker in cppcheck in Packit OpenScanHub configurations

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -8,6 +8,7 @@ upstream_package_name: avahi
 downstream_package_name: avahi
 upstream_tag_template: "v{version}"
 srpm_build_deps: []
+csmock_args: --cppcheck-add-flag=--enable=style
 
 actions:
   post-upstream-clone:


### PR DESCRIPTION
It's prompted by 8e77303a9aed6888677a2bd234cfde5b11faca37, 32fba39e116667bbd9e950b2dd7abd70956b90e8 and
16b6397f15b28ec80d57a892a7f982aad7630e0f and should help to catch issues like that automatically.

See https://github.com/avahi/avahi/pull/641.