### PR TITLE
build-system: switch to localedir

### DIFF
--- a/avahi-common/Makefile.am
+++ b/avahi-common/Makefile.am
@@ -77,7 +77,7 @@ libavahi_common_la_SOURCES = \
 	utf8.c utf8.h \
 	i18n.c i18n.h
 
-libavahi_common_la_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS) -DAVAHI_LOCALEDIR=\"$(avahilocaledir)\"
+libavahi_common_la_CFLAGS = $(AM_CFLAGS) $(PTHREAD_CFLAGS) -DAVAHI_LOCALEDIR=\"$(localedir)\"
 libavahi_common_la_LIBADD = $(AM_LDADD) $(PTHREAD_CFLAGS) $(PTHREAD_LIBS) $(INTLLIBS)
 libavahi_common_la_LDFLAGS = $(AM_LDFLAGS)  -version-info $(LIBAVAHI_COMMON_VERSION_INFO)
 

--- a/avahi-python/avahi-discover/Makefile.am
+++ b/avahi-python/avahi-discover/Makefile.am
@@ -51,7 +51,7 @@ avahi-discover.desktop: avahi-discover.desktop.in
 avahi-discover: avahi-discover.py
 	$(AM_V_GEN)sed -e 's,@PYTHON\@,$(PYTHON),g' \
 		-e 's,@GETTEXT_PACKAGE\@,"$(GETTEXT_PACKAGE)",g' \
-		-e 's,@LOCALEDIR\@,"$(avahilocaledir)",g' \
+		-e 's,@LOCALEDIR\@,"$(localedir)",g' \
 		-e 's,@interfacesdir\@,$(interfacesdir),g' $< > $@ && \
 	chmod +x $@
 

--- a/avahi-ui/Makefile.am
+++ b/avahi-ui/Makefile.am
@@ -30,7 +30,7 @@ desktop_DATA_in_in = bssh.desktop.in.in bvnc.desktop.in.in
 EXTRA_DIST = $(desktop_DATA_in_in)
 
 if HAVE_GTK2OR3
-AM_CFLAGS += -DGNOMELOCALEDIR=\"$(datadir)/locale\"
+AM_CFLAGS += -DGNOMELOCALEDIR=\"$(localedir)\"
 if HAVE_DBUS
 if HAVE_GLIB
 

--- a/configure.ac
+++ b/configure.ac
@@ -420,9 +420,6 @@ AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE],["$GETTEXT_PACKAGE"],[Gettext package])
 AM_GNU_GETTEXT_VERSION([0.19.8])
 AM_GNU_GETTEXT([external])
 
-avahilocaledir='${prefix}/${DATADIRNAME}/locale'
-AC_SUBST(avahilocaledir)
-
 # Check for pkg-config manually first, as if its not installed the
 # PKG_PROG_PKG_CONFIG macro won't be defined.
 AC_CHECK_PROG(have_pkg_config, pkg-config, yes, no)


### PR DESCRIPTION
to get avahi to look for the locales in the right place.

DATADIRNAME is no longer set so avahilocaledir points to non-existent directories like `/usr//locale`. That bespoke variable was introduced back in 2007 and can safely be replaced with localedir (which was introduced in Autoconf 2.59c (2006-04-12)).

Closes: https://github.com/avahi/avahi/issues/644