### PR TITLE
install <avahi-common/dbus.h>

### DIFF
--- a/avahi-common/Makefile.am
+++ b/avahi-common/Makefile.am
@@ -131,8 +131,10 @@ utf8_test_LDADD = $(AM_LDADD)
 
 if HAVE_DBUS
 
+avahi_commoninclude_HEADERS += \
+	dbus.h
+
 noinst_HEADERS = \
-	dbus.h \
 	dbus-watch-glue.h
 
 endif

--- a/avahi-common/dbus.c
+++ b/avahi-common/dbus.c
@@ -27,6 +27,7 @@
 
 #include <avahi-common/error.h>
 #include <avahi-common/dbus.h>
+#include <dbus/dbus.h>
 
 static const char * const table[- AVAHI_ERR_MAX] = {
     AVAHI_DBUS_ERR_OK,

--- a/avahi-common/dbus.h
+++ b/avahi-common/dbus.h
@@ -23,7 +23,6 @@
 /** \file dbus.h Some definitions for the D-Bus interface */
 
 #include <avahi-common/cdecl.h>
-#include <dbus/dbus.h>
 
 AVAHI_C_DECL_BEGIN
 


### PR DESCRIPTION
This header is useful when writing custom D-Bus clients for Avahi.