### PR TITLE
Add a shell completion function for zsh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,7 +79,8 @@ SUBDIRS = \
 	avahi-ui \
 	avahi-ui-sharp \
 	avahi-libevent \
-	po
+	po \
+	completion
 
 DX_INPUT = \
 	$(srcdir)/avahi-common/address.h \

--- a/completion/Makefile.am
+++ b/completion/Makefile.am
@@ -1,0 +1,25 @@
+# This file is part of avahi.
+#
+# avahi is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# avahi is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with avahi; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# USA.
+
+if ENABLE_ZSH_COMPLETION
+
+zshcompdir = $(datadir)/zsh/site-functions
+dist_zshcomp_DATA = _avahi
+
+endif
+
+EXTRA_DIST = _avahi

--- a/completion/_avahi
+++ b/completion/_avahi
@@ -1,0 +1,54 @@
+#compdef avahi-browse avahi-browse-domains avahi-resolve avahi-resolve-address avahi-resolve-host-name
+
+# Completion function for zsh
+
+local curcontext="$curcontext" pri ret=1
+local -A opt_args
+local -a state line args serv desc disp
+
+args=(
+  '(- 1)'{-h,--help}'[display usage information]'
+  '(- 1)'{-V,--version}'[display version information]'
+  '(-v --verbose)'{-v,--verbose}'[enable verbose mode]'
+)
+
+case $service in
+  *-browse*)
+    serv=( ${(f)"$(_call_program service-types avahi-browse -bk)"} )
+    desc=( ${(f)"$(_call_program service-types-description avahi-browse -b)"} )
+    (( $#desc )) && print -v disp -f '%s:%s' ${serv:^desc}
+
+    _arguments -s -S -C $args \
+      '(-D --browse-domains -a --all -b --dump-db)'{-D,--browse-domains}'[browse for browsing domains instead of services]' \
+      '(-D --browse-domains -a --all -b --dump-db)'{-a,--all}'[show all services, regardless of the type]' \
+      '(-d --domain)'{-d+,--domain=}'[specify domain to browse in]:domain' \
+      '(-t --terminate)'{-t,--terminate}'[terminate after dumping a more or less complete list]' \
+      '(-c --cache)'{-c,--cache}'[terminate after dumping all entries from the cache]' \
+      '(-l --ignore-local)'{-l,--ignore-local}'[ignore local services]' \
+      '(-r --resolve)'{-r,--resolve}'[resolve services found]' \
+      '(-f --no-fail)'{-f,--no-fail}"[don't fail if the daemon is not available]" \
+      '(-p --parsable)'{-p,--parsable}'[output in parsable format]' \
+      '(-k --no-db-lookup)'{-k,--no-db-lookup}"[don't lookup service types]" \
+      '(-D --browse-domains -a --all -b --dump-db)'{-b,--dump-db}'[dump service type database]' \
+      '1: :->service-types' && ret=0
+
+    [[ -n $state ]] && _describe -t services "service type" disp && ret=0
+  ;;
+  *-resolve*)
+    if (( ${words[(I)(-n|--name)]} )) || [[ $service = *-host-name ]]; then
+       args=( '*:host:_hosts' )
+       pri=1
+    fi
+    if (( ${words[(I)(-a|--address)]} )) || [[ $service = *-address && -n $pri ]]; then
+       args=( '*: :_guard "^-*" address' )
+    fi
+
+    _arguments -s -S $args \
+      '(-a --address -n --name -h --help -V --version)'{-a,--address}'[resolve address]' \
+      '(-a --address -n --name -h --help -V --version)'{-n,--name}'[resolve host name]' \
+      '(-4)-6[lookup IPv6 address]' \
+      '(-6)-4[lookup IPv4 address]' && ret=0
+  ;;
+esac
+
+return ret

--- a/configure.ac
+++ b/configure.ac
@@ -1152,6 +1152,20 @@ if test "x$with_systemdsystemunitdir" != xno; then
 fi
 AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno ])
 
+#
+# Install zsh completion?
+#
+AC_ARG_ENABLE(zsh-completion,
+	AS_HELP_STRING([--disable-zsh-completion],[Disable installation of zsh completion file]),
+        [case "${enableval}" in
+                yes) ENABLE_ZSH_COMPLETION=yes ;;
+                no)  ENABLE_ZSH_COMPLETION=no ;;
+                *) AC_MSG_ERROR(bad value ${enableval} for --disable-zsh-completion) ;;
+        esac],
+        [ENABLE_ZSH_COMPLETION=yes])
+
+AM_CONDITIONAL(ENABLE_ZSH_COMPLETION, test "x$ENABLE_ZSH_COMPLETION" = "xyes")
+
 # ==========================================================================
 AC_CONFIG_FILES([
 Makefile
@@ -1189,6 +1203,7 @@ avahi-autoipd/Makefile
 avahi-ui/Makefile
 avahi-libevent/Makefile
 po/Makefile.in
+completion/Makefile
 ])
 AC_OUTPUT
 
@@ -1212,6 +1227,7 @@ echo "
     Enable GTK 3.0:                            ${HAVE_GTK3}
     Enable D-Bus:                              ${HAVE_DBUS}
     With XML:                                  ${with_xml}
+    Install Zsh completion:                    ${ENABLE_ZSH_COMPLETION}
     Enable GDBM:                               ${HAVE_GDBM}
     Enable DBM:                                ${HAVE_DBM}
     Enable libdaemon:                          ${HAVE_LIBDAEMON}


### PR DESCRIPTION
This is PR #152 again but with integration to the build system added. (I don't have permissions to reopen the previous PR).

The existing build system seems to be generous in the use of configure --disable/--enable--with etc arguments so this adds `--disable-zsh-completion` for users that want to prevent the installation of the completion files. Let me know if you want a different approach, or different naming or other tweaks to that.

I also checked that the completion file is still valid and up-to-date for the current state of avahi and didn't see any changes that might need to be reflected in the completion function.