### PR TITLE
Add config option to always allow publishing of link-local address 

### DIFF
--- a/avahi-core/core.h
+++ b/avahi-core/core.h
@@ -70,6 +70,7 @@ typedef struct AvahiServerConfig {
     unsigned n_cache_entries_max;     /**< Maximum number of cache entries per interface */
     AvahiUsec ratelimit_interval;     /**< If non-zero, rate-limiting interval parameter. */
     unsigned ratelimit_burst;         /**< If ratelimit_interval is non-zero, rate-limiting burst parameter. */
+    int always_publish_linklocal;     /**< Always publish link-local addresses, even if global addresses are configured on the same interface */
 } AvahiServerConfig;
 
 /** Allocate a new mDNS responder object. */

--- a/avahi-core/iface.c
+++ b/avahi-core/iface.c
@@ -707,14 +707,20 @@ int avahi_interface_address_is_relevant(AvahiInterfaceAddress *a) {
     if (a->global_scope && !a->deprecated)
         return 1;
 
-    /* Publish link-local and deprecated IP addresses only if they are
-     * the only ones on the link */
-    for (b = a->interface->addresses; b; b = b->address_next) {
-        if (b == a)
-            continue;
+    if (a->monitor->server->config.always_publish_linklocal) {
+        /* Publish link-local as long as it's not deprecated */
+        if (!a->deprecated)
+            return 1;
+    }else {
+        /* Publish link-local and deprecated IP addresses only if they are
+        * the only ones on the link */
+        for (b = a->interface->addresses; b; b = b->address_next) {
+            if (b == a)
+                continue;
 
-        if (b->global_scope && !b->deprecated)
-            return 0;
+            if (b->global_scope && !b->deprecated)
+                return 0;
+        }
     }
 
     return 1;

--- a/avahi-core/server.c
+++ b/avahi-core/server.c
@@ -1662,6 +1662,7 @@ AvahiServerConfig* avahi_server_config_init(AvahiServerConfig *c) {
     c->enable_wide_area = 0;
     c->n_wide_area_servers = 0;
     c->disallow_other_stacks = 0;
+    c->always_publish_linklocal = 0;
     c->browse_domains = NULL;
     c->disable_publishing = 0;
     c->allow_point_to_point = 0;

--- a/avahi-daemon/avahi-daemon.conf
+++ b/avahi-daemon/avahi-daemon.conf
@@ -36,6 +36,7 @@ use-ipv6=yes
 #clients-max=4096
 #objects-per-client-max=1024
 #entries-per-entry-group-max=32
+#always-publish-linklocal=yes
 ratelimit-interval-usec=1000000
 ratelimit-burst=1000
 

--- a/avahi-daemon/main.c
+++ b/avahi-daemon/main.c
@@ -672,6 +672,8 @@ static int load_config_file(DaemonConfig *c) {
                     c->server_config.use_iff_running = is_yes(p->value);
                 else if (strcasecmp(p->key, "disallow-other-stacks") == 0)
                     c->server_config.disallow_other_stacks = is_yes(p->value);
+                else if (strcasecmp(p->key, "always-publish-linklocal") == 0)
+                    c->server_config.always_publish_linklocal = is_yes(p->value);
                 else if (strcasecmp(p->key, "host-name-from-machine-id") == 0) {
                     if (*(p->value) == 'y' || *(p->value) == 'Y') {
                         char *machine_id = get_machine_id();

--- a/man/avahi-daemon.conf.5.xml.in
+++ b/man/avahi-daemon.conf.5.xml.in
@@ -142,6 +142,17 @@
     </option>
 
     <option>
+      <p><opt>always-publish-linklocal=</opt> Takes a boolean value
+      ("yes" or "no"). If set to "yes", avahi-daemon will publish a
+      linklocal address assigned to an interface, even if that
+      interface has other global addresses assigned to it. This
+      behaviour is as per RFC6762. If set to "no", avahi-daemon
+      will not publish a linklocal address if the interface has other
+      global addresses assigned to it, which has been the default
+      for a long time. Defaults to "no".</p>
+    </option>
+
+    <option>
       <p><opt>allow-point-to-point=</opt> Takes a boolean value
       ("yes" or "no"). If set to "yes" avahi-daemon will make use of
       interfaces with the POINTOPOINT flag set. This option defaults


### PR DESCRIPTION
Currently, `avahi-daemon` will only publish a link-local address on a interface, IFF there are no other "global" addresses assigned to the same interface. This was widely discussed in https://github.com/avahi/avahi/issues/243, and it seems that the current behavior is counter to RFC6762. 

This PR adds a new config option to `avahi-daemon.conf`, `always-publish-linklocal` which defaults to `no`, but when set to `yes`, will always publish a link-local address regardless other addresses on the same interface.

Hopefully this approach maintains backward compatibility and yet allows users to configure behavior.

P.S. This is my first PR to avahi, let me know if I'm missing something, I'll try to fix asap.