### PR TITLE
qt-watch: fixed wrong set last event after activate signal goto WatchOut

### DIFF
--- a/avahi-qt/qt-watch.cpp
+++ b/avahi-qt/qt-watch.cpp
@@ -90,7 +90,7 @@ void AvahiWatch::gotIn()
 
 void AvahiWatch::gotOut()
 {
-    m_lastEvent = AVAHI_WATCH_IN;
+    m_lastEvent = AVAHI_WATCH_OUT;
     m_incallback=true;
     m_callback(this,m_fd,m_lastEvent,m_userdata);
     m_incallback=false;


### PR DESCRIPTION
@evverx,
in qt version, last event is incorrectly saved when last callback activated signal was as socket on write, i.e. AVAHI_WATCH_OUT.