### PR TITLE
gobject: fixed getting warning invalid prop id after set value prop flags

### DIFF
--- a/avahi-gobject/ga-client.c
+++ b/avahi-gobject/ga-client.c
@@ -103,6 +103,7 @@ static void ga_client_get_property(GObject * object,
             break;
         case PROP_FLAGS:
             g_value_set_enum(value, priv->flags);
+            break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
             break;


### PR DESCRIPTION
@evverx, this PR fixed inconspicuous misprint due to which continues to be executed in `default:` block after execution `case PROP_FLAGS:` block.