### PR TITLE
core/daemon/gobj: align structures (8 byte) for 64bit platforms

### DIFF
--- a/avahi-core/rr.h
+++ b/avahi-core/rr.h
@@ -53,8 +53,8 @@ enum {
     reference counter. The structure is intended to be treated as "immutable", no
     changes should be imposed after creation */
 typedef struct AvahiKey {
-    int ref;           /**< Reference counter */
     char *name;        /**< Record name */
+    int ref;           /**< Reference counter */
     uint16_t clazz;    /**< Record class, one of the AVAHI_DNS_CLASS_xxx constants */
     uint16_t type;     /**< Record type, one of the AVAHI_DNS_TYPE_xxx constants */
 } AvahiKey;
@@ -63,8 +63,8 @@ typedef struct AvahiKey {
  * be treated as "immutable", no changes should be imposed after
  * creation. */
 typedef struct AvahiRecord {
-    int ref;         /**< Reference counter */
     AvahiKey *key;   /**< Reference to the query key of this record */
+    int ref;         /**< Reference counter */
 
     uint32_t ttl;     /**< DNS TTL of this record */
 

--- a/avahi-core/rrlist.c
+++ b/avahi-core/rrlist.c
@@ -33,8 +33,8 @@
 typedef struct AvahiRecordListItem AvahiRecordListItem;
 
 struct AvahiRecordListItem {
-    int read;
     AvahiRecord *record;
+    int read;
     int unicast_response;
     int flush_cache;
     int auxiliary;

--- a/avahi-daemon/dbus-internal.h
+++ b/avahi-daemon/dbus-internal.h
@@ -49,10 +49,10 @@ typedef struct RecordBrowserInfo RecordBrowserInfo;
 #define DEFAULT_START_DELAY_MS 10
 
 struct EntryGroupInfo {
-    unsigned id;
     Client *client;
     AvahiSEntryGroup *entry_group;
     char *path;
+    unsigned id;
 
     unsigned n_entries;
 

--- a/avahi-daemon/static-hosts.c
+++ b/avahi-daemon/static-hosts.c
@@ -37,13 +37,13 @@
 typedef struct StaticHost StaticHost;
 
 struct StaticHost {
+    AVAHI_LLIST_FIELDS(StaticHost, hosts);
+
     AvahiSEntryGroup *group;
     int iteration;
 
-    char *host;
     AvahiAddress address;
-
-    AVAHI_LLIST_FIELDS(StaticHost, hosts);
+    char *host;
 };
 
 static AVAHI_LLIST_HEAD(StaticHost, hosts) = NULL;

--- a/avahi-gobject/ga-client.c
+++ b/avahi-gobject/ga-client.c
@@ -187,16 +187,16 @@ GaClient *ga_client_new(GaClientFlags flags) {
 
 static GQuark detail_for_state(AvahiClientState state) {
     static struct {
-        AvahiClientState state;
         const gchar *name;
         GQuark quark;
+        AvahiClientState state;
     } states[] = {
-        { AVAHI_CLIENT_S_REGISTERING, "registering", 0},
-        { AVAHI_CLIENT_S_RUNNING, "running", 0},
-        { AVAHI_CLIENT_S_COLLISION, "collision", 0},
-        { AVAHI_CLIENT_FAILURE, "failure", 0},
-        { AVAHI_CLIENT_CONNECTING, "connecting", 0},
-        { 0, NULL, 0}
+        { "registering", 0, AVAHI_CLIENT_S_REGISTERING},
+        { "running", 0, AVAHI_CLIENT_S_RUNNING},
+        { "collision", 0, AVAHI_CLIENT_S_COLLISION},
+        { "failure", 0, AVAHI_CLIENT_FAILURE},
+        { "connecting", 0, AVAHI_CLIENT_CONNECTING},
+        { NULL, 0, 0}
     };
     int i;
 

--- a/avahi-gobject/ga-entry-group.c
+++ b/avahi-gobject/ga-entry-group.c
@@ -52,10 +52,10 @@ enum {
 typedef struct _GaEntryGroupPrivate GaEntryGroupPrivate;
 
 struct _GaEntryGroupPrivate {
-    GaEntryGroupState state;
     GaClient *client;
     AvahiEntryGroup *group;
     GHashTable *services;
+    GaEntryGroupState state;
     gboolean dispose_has_run;
 };
 
@@ -185,16 +185,16 @@ static void _free_service(gpointer data) {
 
 static GQuark detail_for_state(AvahiEntryGroupState state) {
     static struct {
-        AvahiEntryGroupState state;
         const gchar *name;
         GQuark quark;
+        AvahiEntryGroupState state;
     } states[] = {
-        { AVAHI_ENTRY_GROUP_UNCOMMITED, "uncommitted", 0},
-        { AVAHI_ENTRY_GROUP_REGISTERING, "registering", 0},
-        { AVAHI_ENTRY_GROUP_ESTABLISHED, "established", 0},
-        { AVAHI_ENTRY_GROUP_COLLISION, "collision", 0},
-        { AVAHI_ENTRY_GROUP_FAILURE, "failure", 0},
-        { 0, NULL, 0}
+        { "uncommitted", 0, AVAHI_ENTRY_GROUP_UNCOMMITED},
+        { "registering", 0, AVAHI_ENTRY_GROUP_REGISTERING},
+        { "established", 0, AVAHI_ENTRY_GROUP_ESTABLISHED},
+        { "collision", 0, AVAHI_ENTRY_GROUP_COLLISION},
+        { "failure", 0, AVAHI_ENTRY_GROUP_FAILURE},
+        { NULL, 0, 0}
     };
     int i;
 

--- a/avahi-gobject/ga-entry-group.h
+++ b/avahi-gobject/ga-entry-group.h
@@ -43,14 +43,14 @@ typedef struct _GaEntryGroup GaEntryGroup;
 typedef struct _GaEntryGroupClass GaEntryGroupClass;
 
 struct _GaEntryGroupService {
-    AvahiIfIndex interface;
-    AvahiProtocol protocol;
-    AvahiPublishFlags flags;
     gchar *name;
     gchar *type;
     gchar *domain;
     gchar *host;
     guint16 port;
+    AvahiIfIndex interface;
+    AvahiProtocol protocol;
+    AvahiPublishFlags flags;
 };
 
 struct _GaEntryGroupClass {


### PR DESCRIPTION
@evverx,
Smaller size structure or class, higher chance putting into cpu cache, changes require checking using yours benchmark, I haven't figured out how to run bench in your project yet.

Most processors are already 64 bit, so the change won't make it any worse.

Info about technique:

https://stackoverflow.com/a/20882083
https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/
https://en.wikipedia.org/wiki/Data_structure_alignment

Affected structs:

- AvahiRecordListItem 48 -> 40 bytes
- AvahiClientStates 24 -> 16 bytes
- EntryGroupInfo 56 -> 48 bytes
- _GaEntryGroupPrivate 40 -> 32 bytes
- AvahiRecord 40 -> 32 bytes
- StaticHost 64 -> 56 bytes
- AvahiKey 24 -> 16 bytes
- _GaEntryGroupService 56 -> 48 bytes