### PR TITLE
Avoid conflicting probes after TXT data has been updated

### DIFF
--- a/avahi-core/announce.h
+++ b/avahi-core/announce.h
@@ -65,5 +65,6 @@ void avahi_goodbye_interface(AvahiServer *s, AvahiInterface *i, int send_goodbye
 void avahi_goodbye_entry(AvahiServer *s, AvahiEntry *e, int send_goodbye, int rem);
 
 void avahi_reannounce_entry(AvahiServer *s, AvahiEntry *e);
+void avahi_reannounce_entry_interface(AvahiServer *s, AvahiEntry *e, AvahiInterface *i, unsigned msec);
 
 #endif

--- a/avahi-core/internal.h
+++ b/avahi-core/internal.h
@@ -66,6 +66,7 @@ struct AvahiEntry {
     AvahiSEntryGroup *group;
 
     int dead;
+    int lost;
 
     AvahiPublishFlags flags;
     AvahiRecord *record;


### PR DESCRIPTION
RFC6762, section 8.2, states that own probe packages can erroneously be detected as conflicting probe if the internal copy of the probe message has been updated meanwhile before receiving the echoed message:

> The logic ... is to
> guard against stale probe packets on the network (possibly even stale
> probe packets sent moments ago by this host itself, before some
> configuration change, which may be echoed back after a short delay by
> some Ethernet switches and some 802.11 base stations).

This is exactly the problem I described in #654 some time ago. The current
reaction of Avahi after receiving an _lexicographically earlier_ conflicting probe
is to immediately withdraw the own records (which doesn't match the behavior
requested by the RFC):

> If the host finds that its
> own data is lexicographically earlier, then it defers to the winning
> host by waiting one second, and then begins probing for this record
> again.

If I understand the RFC correctly, the actual withdrawing of our own records
(only in case of a _real_ conflict) shall happen after receiving a conflicting response
packet:

> If the
> winning simultaneous probe was from a real other host on the network,
> then after one second it will have completed its probing, and will
> answer subsequent probes.

I assume that this is already done by calling `handle_conflict()` from `handle_response_packet()`.