### PR TITLE
Make data member as big as IPv6 address

### DIFF
--- a/avahi-common/address.h
+++ b/avahi-common/address.h
@@ -71,9 +71,9 @@ typedef struct AvahiAddress {
     AvahiProtocol proto; /**< Address family */
 
     union {
-        AvahiIPv6Address ipv6;  /**< Address when IPv6 */
-        AvahiIPv4Address ipv4;  /**< Address when IPv4 */
-        uint8_t data[1];        /**< Type-independent data field */
+        AvahiIPv6Address ipv6;                   /**< Address when IPv6 */
+        AvahiIPv4Address ipv4;                   /**< Address when IPv4 */
+        uint8_t data[sizeof(AvahiIPv6Address)];  /**< Type-independent data field */
     } data;
 } AvahiAddress;
 


### PR DESCRIPTION
Unfortunately, recent FORTIFY_SOURCE hardening for inet_pton() can't deal with our type independent "data[1]" union member trick.

Fixes #699