### PR TITLE
Get hostname from avahi-set-host-name tool

### DIFF
--- a/avahi-utils/avahi-set-host-name.c
+++ b/avahi-utils/avahi-set-host-name.c
@@ -116,7 +116,10 @@ static int parse_command_line(Config *c, int argc, char *argv[]) {
     }
 
     if (c->command == COMMAND_UNSPEC) {
-        if (optind != argc-1) {
+	if (argc == 1) {
+	    c->command = COMMAND_GET;
+	    return 0;
+	} else if (optind != argc-1) {
             fprintf(stderr, _("Invalid number of arguments, expecting exactly one.\n"));
             return -1;
         }

--- a/man/avahi-set-host-name.1.xml.in
+++ b/man/avahi-set-host-name.1.xml.in
@@ -24,14 +24,17 @@
   <manpage name="avahi-set-host-name" section="1" desc="Change mDNS host name">
 
 	<synopsis>
-      <cmd>avahi-set-host-name <arg>host-name</arg></cmd>
+      <cmd>avahi-set-host-name <arg>[host-name]</arg></cmd>
 	</synopsis>
 
     <description>
       <p>Set the mDNS host name of a currently running Avahi
       daemon. The effect of this operation is not persistent across
       daemon restarts. This operation is usually privileged.</p>
-	</description>
+
+      <p>Gets the current mDNS host name of a currently running Avahi
+      daemon when no parameter is specified.</p>
+    </description>
 
 	<options>
 
@@ -49,6 +52,12 @@
 	  <option>
 		<p><opt>-V | --version</opt></p>
 		<optdesc><p>Show version information.</p></optdesc>
+	  </option>
+
+
+	  <option>
+		<p><opt>-g | --get</opt></p>
+		<optdesc><p>Show current hostname.</p></optdesc>
 	  </option>
 
 


### PR DESCRIPTION
Provide simple way of getting current Avahi hostname from shell. It might have changed because conflict, make it simple to check it.