### PR TITLE
configure.ac: Check if inotify functions are available without linking extra libs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -398,7 +398,15 @@ fi
 AM_CONDITIONAL(HAVE_DLOPEN, test "x$HAVE_DLOPEN" = "xyes")
 
 have_inotify=no
-AC_CHECK_HEADERS([sys/inotify.h], [have_inotify=yes])
+AC_LINK_IFELSE(
+        [AC_LANG_SOURCE([
+#include <sys/inotify.h>
+int main () {
+    return (-1 == inotify_init());
+}])],
+        [AC_MSG_RESULT([yes]); have_inotify=yes],
+        [AC_MSG_RESULT([no])]
+    )
 
 AM_CONDITIONAL(HAVE_INOTIFY, test "x$have_inotify" = "xyes")
 


### PR DESCRIPTION
This is important for !Linux OSes which may implement inotify API via 3rd party libinotify-kqueue library.

This is a prerequisite for the FreeBSD CI ( https://github.com/avahi/avahi/issues/724 )