### PR TITLE
Fix multiple issues in `lookup_drop_cname` (supersedes #286)

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -228,8 +228,9 @@ fi
 run ./avahi-core/avahi-test
 run ./avahi-core/querier-test
 
-for test_case in self_loop retransmit_cname one_normal one_loop two_normal two_loop two_loop_inner two_loop_inner2 three_normal three_loop diamond cname_answer_diamond cname_answer; do
-    run ./avahi-core/cname-test $test_case
+for test_case in self_loop self_loop_answer retransmit_cname one_normal one_loop two_normal two_loop two_loop_inner two_loop_inner2 three_normal three_loop diamond cname_answer_diamond cname_answer cname_answer_removed cname_max_reached cname_answer_triangle_removed; do
+    run ./avahi-core/cname-test $test_case any-transport
+    run ./avahi-core/cname-test $test_case multicast
 done
 
 run ./examples/glib-integration

--- a/avahi-core/browse.c
+++ b/avahi-core/browse.c
@@ -36,8 +36,6 @@
 #include "domain-util.h"
 #include "rr-util.h"
 
-#define AVAHI_LOOKUPS_PER_BROWSER_MAX 15
-
 struct AvahiSRBLookup {
     AvahiSRecordBrowser *record_browser;
 

--- a/avahi-core/browse.c
+++ b/avahi-core/browse.c
@@ -153,6 +153,19 @@ static AvahiSRBLookup* lookup_ref(AvahiSRBLookup *l) {
     return l;
 }
 
+static int avahi_lookup_match(const AvahiSRBLookup *l, AvahiIfIndex interface, AvahiProtocol protocol, AvahiLookupFlags flags, const AvahiKey *key) {
+    if (l->interface != AVAHI_IF_UNSPEC && l->interface != interface)
+        return 0;
+
+    if (l->protocol != AVAHI_PROTO_UNSPEC && l->protocol != protocol)
+        return 0;
+
+    if (flags != 0 && l->flags != flags)
+        return 0;
+
+    return avahi_key_equal(l->key, key);
+}
+
 static AvahiSRBLookup *lookup_find(
     AvahiSRecordBrowser *b,
     AvahiIfIndex interface,
@@ -166,11 +179,7 @@ static AvahiSRBLookup *lookup_find(
 
     for (l = b->lookups; l; l = l->lookups_next) {
 
-        if ((l->interface == AVAHI_IF_UNSPEC || l->interface == interface) &&
-            (l->protocol == AVAHI_PROTO_UNSPEC || l->protocol == protocol) &&
-            l->flags == flags &&
-            avahi_key_equal(l->key, key))
-
+        if (avahi_lookup_match(l, interface, protocol, flags, key))
             return l;
     }
 
@@ -290,7 +299,7 @@ static void lookup_multicast_callback(
             if (r->key->clazz == AVAHI_DNS_CLASS_IN &&
                 r->key->type == AVAHI_DNS_TYPE_CNAME)
                 /* It's a CNAME record, so let's drop that query! */
-                lookup_drop_cname(l, interface, protocol, 0, r);
+                lookup_drop_cname(l, interface, protocol, b->flags, r);
             else {
                 /* It's a normal record, so let's call the user callback */
 
@@ -478,10 +487,7 @@ static void lookup_drop_cname(AvahiSRBLookup *l, AvahiIfIndex interface, AvahiPr
 
         assert(n);
 
-        if ((n->interface == AVAHI_IF_UNSPEC || n->interface == interface) &&
-            (n->protocol == AVAHI_PROTO_UNSPEC || n->protocol == protocol) &&
-            n->flags == flags &&
-            avahi_key_equal(n->key, k))
+        if (avahi_lookup_match(n, interface, protocol, flags, k))
             break;
     }
 

--- a/avahi-core/browse.c
+++ b/avahi-core/browse.c
@@ -167,7 +167,7 @@ static AvahiSRBLookup *lookup_find(
     for (l = b->lookups; l; l = l->lookups_next) {
 
         if ((l->interface == AVAHI_IF_UNSPEC || l->interface == interface) &&
-            (l->interface == AVAHI_PROTO_UNSPEC || l->protocol == protocol) &&
+            (l->protocol == AVAHI_PROTO_UNSPEC || l->protocol == protocol) &&
             l->flags == flags &&
             avahi_key_equal(l->key, key))
 
@@ -479,7 +479,7 @@ static void lookup_drop_cname(AvahiSRBLookup *l, AvahiIfIndex interface, AvahiPr
         assert(n);
 
         if ((n->interface == AVAHI_IF_UNSPEC || n->interface == interface) &&
-            (n->interface == AVAHI_PROTO_UNSPEC || n->protocol == protocol) &&
+            (n->protocol == AVAHI_PROTO_UNSPEC || n->protocol == protocol) &&
             n->flags == flags &&
             avahi_key_equal(n->key, k))
             break;

--- a/avahi-core/browse.h
+++ b/avahi-core/browse.h
@@ -28,6 +28,8 @@
 #include "dns.h"
 #include "lookup.h"
 
+#define AVAHI_LOOKUPS_PER_BROWSER_MAX 15
+
 typedef struct AvahiSRBLookup AvahiSRBLookup;
 
 struct AvahiSRecordBrowser {

--- a/avahi-core/cache.c
+++ b/avahi-core/cache.c
@@ -32,7 +32,7 @@
 #include "log.h"
 #include "rr-util.h"
 
-static void remove_entry(AvahiCache *c, AvahiCacheEntry *e) {
+void avahi_cache_remove_entry(AvahiCache *c, AvahiCacheEntry *e) {
     AvahiCacheEntry *t;
 
     assert(c);
@@ -94,7 +94,7 @@ void avahi_cache_free(AvahiCache *c) {
     assert(c);
 
     while (c->entries)
-        remove_entry(c, c->entries);
+        avahi_cache_remove_entry(c, c->entries);
     assert(c->n_entries == 0);
 
     avahi_hashmap_free(c->hashmap);
@@ -180,7 +180,7 @@ static void elapse_func(AvahiTimeEvent *t, void *userdata) {
         case AVAHI_CACHE_GOODBYE_FINAL:
         case AVAHI_CACHE_REPLACE_FINAL:
 
-            remove_entry(e->cache, e);
+            avahi_cache_remove_entry(e->cache, e);
 
             e = NULL;
 /*         avahi_log_debug("Removing entry from cache due to expiration (%s)", txt); */
@@ -434,7 +434,7 @@ void avahi_cache_flush(AvahiCache *c) {
     assert(c);
 
     while (c->entries)
-        remove_entry(c, c->entries);
+        avahi_cache_remove_entry(c, c->entries);
 }
 
 /*** Passive observation of failure ***/

--- a/avahi-core/cache.h
+++ b/avahi-core/cache.h
@@ -89,6 +89,8 @@ void* avahi_cache_walk(AvahiCache *c, AvahiKey *pattern, AvahiCacheWalkCallback 
 
 int avahi_cache_entry_half_ttl(AvahiCache *c, AvahiCacheEntry *e);
 
+void avahi_cache_remove_entry(AvahiCache *c, AvahiCacheEntry *e);
+
 /** Start the "Passive observation of Failure" algorithm for all
  * records of the specified key. The specified address is  */
 void avahi_cache_start_poof(AvahiCache *c, AvahiKey *key, const AvahiAddress *a);


### PR DESCRIPTION
This PR supersedes #286 (as it cherry-picks @szenker's and @pemensik's commits).

This PR fixes a couple of issues with `lookup_drop_cname`, which cause lookups to be retained even after their corresponding CNAME records are removed. It also corrects the lookup flags comparison in `lookup_drop_cname` which never matched the `flags` value.

At the time, #286 was blocked on #551 being merged - #682, which superseded #551 was merged a couple weeks back.

Thanks to @szenker and @pemensik for their work on #286!