### PR TITLE
ci: install dfuzzer and radamsa on FreeBSD and switch to socat

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -62,7 +62,7 @@ case "$1" in
         apt-get install -y gcc clang lcov
         apt-get install -y mono-mcs monodoc-base libmono-posix4.0-ci
 
-        apt-get install -y valgrind ncat ldnsutils
+        apt-get install -y valgrind socat ldnsutils
 
         apt-get install -y libglib2.0-dev meson
         install_dfuzzer
@@ -77,7 +77,7 @@ case "$1" in
         pkg install -y gettext-runtime gettext-tools gmake intltool \
             gobject-introspection pkgconf expat libdaemon dbus-glib dbus gdbm \
             libevent glib automake libtool libinotify qt5-core qt5-buildtools \
-            gtk3 py311-pygobject py311-dbus py311-gdbm mono git meson
+            gtk3 py311-pygobject py311-dbus py311-gdbm mono git meson socat
         # some deps pull in avahi itself, remove it
         pkg remove -fy avahi-app
         install_dfuzzer

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -100,7 +100,7 @@ dbus_call GetAlternativeHostName "s" "a-2147483647"
 # https://github.com/avahi/avahi/issues/526
 dbus_call GetAlternativeServiceName "s" "a #2147483647"
 
-printf "%s\n" "RESOLVE-ADDRESS $(perl -e 'print q/A/ x 1014')" | ncat -w1 -U /run/avahi-daemon/socket
+printf "%s\n" "RESOLVE-ADDRESS $(perl -e 'print q/A/ x 1014')" | socat - unix-connect:/run/avahi-daemon/socket
 
 cmds=(
     "HELP"
@@ -117,11 +117,11 @@ cmds=(
 mkdir -p CORPUS
 for cmd in "${cmds[@]}"; do
     printf "%s\n" "$cmd" >CORPUS/"$cmd"
-    printf "%s\n" "$cmd" | ncat -w1 -U /run/avahi-daemon/socket
+    printf "%s\n" "$cmd" | socat - unix-connect:/run/avahi-daemon/socket
 done
 
 timeout --foreground 180 bash -c 'while :; do
-    radamsa -r CORPUS | ncat -w1 -i0.5 -U /run/avahi-daemon/socket
+    radamsa -r CORPUS | socat -T2 - unix-connect:/run/avahi-daemon/socket
 done >&/dev/null' || true
 
 avahi-browse -varpt


### PR DESCRIPTION
to make it possible to fuzz the D-Bus API and the simple protocol there. socat is used because `ncat -U` isn't universally supported.

Those things aren't run on FreeBSD yet because the smoke tests still depend on systemd (https://github.com/avahi/avahi/issues/727) but that should be addressed later. Until then all those things are readily available on the CI and can be easily run manually.