### PR TITLE
ci: set runstatedir to /var/run on FreeBSD

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -132,7 +132,6 @@ case "$1" in
             "--enable-core-docs"
             "--enable-tests"
             "--localstatedir=/var"
-            "--runstatedir=/run"
             "--sysconfdir=/etc"
         )
 
@@ -140,11 +139,13 @@ case "$1" in
             autogen_args+=(
                 "--prefix=/usr"
                 "--libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+                "--runstatedir=/run"
             )
         else
             autogen_args+=(
                 "--prefix=/usr/local"
                 "--libdir=/usr/local/lib"
+                "--runstatedir=/var/run"
                 "--disable-libsystemd"
                 "--disable-manpages"
             )


### PR DESCRIPTION
that's where runtime stuff goes there.

For example the port replaces `/run` to `/var/run` in https://github.com/freebsd/freebsd-ports/blob/2208426e57834d9a78c63632f2112091e9168665/net/avahi-app/Makefile#L102C26-L102C43

and the init script expects the pid file there
https://github.com/freebsd/freebsd-ports/blob/2208426e57834d9a78c63632f2112091e9168665/net/avahi-app/files/patch-initscript_freebsd_avahi-daemon.sh.in#L24