### PR TITLE
ci: replace systemd-cat with logger

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -195,9 +195,9 @@ case "$1" in
         # It shouldn't actually change any settings so the action just
         # logs what it receives from avahi-daemon.
         cat <<'EOL' >avahi-dnsconfd/avahi-dnsconfd.action
-#!/bin/bash
+#!/usr/bin/env bash
 
-printf "%s\n" "<$1> <$2> <$3> <$4>" | systemd-cat
+printf "%s\n" "<$1> <$2> <$3> <$4>" | logger
 EOL
 
         if [[ "$VALGRIND" == true && "$OS" != FreeBSD ]]; then


### PR DESCRIPTION
and avoid using /bin/bash directly.

Without this patch it fails with
```
Nov  9 02:34:56  avahi-dnsconfd[52267]: execv(/usr/local/etc/avahi/avahi-dnsconfd.action) failed: No such file or directory
Nov  9 02:34:56  avahi-dnsconfd[52252]: Script returned with non-zero exit code 1
```
and so on on FreeBSD.