### PR TITLE
ci: remove kludges from Packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -19,13 +19,6 @@ actions:
     # Drop all patches apart from avahi-0.6.30-mono-libdir.patch
     - "sed -ri '/^Patch[0-9]+\\:.+\\.patch/d' .packit_rpm/avahi.spec"
     - "sed -ri '/^## downstream patches/aPatch100: avahi-0.6.30-mono-libdir.patch' .packit_rpm/avahi.spec"
-    # https://github.com/avahi/avahi/pull/376
-    - "sed -i '/avahi-dbus.conf/s/sysconf/data/' .packit_rpm/avahi.spec"
-    # Run make check
-    - "sed -i '/^%check$/amake check VERBOSE=1' .packit_rpm/avahi.spec"
-    # https://github.com/avahi/avahi/pull/513
-    - "sed -i '/^%configure/a--enable-libsystemd \\\\' .packit_rpm/avahi.spec"
-    - "sed -i '/^BuildRequires: *automake/aBuildRequires: systemd-devel' .packit_rpm/avahi.spec"
 
 jobs:
 - job: copr_build


### PR DESCRIPTION
Fedora started to run `make check` in
https://src.fedoraproject.org/rpms/avahi/c/e8ad0f7bbb7fdf82a0f0be128bab07b5928322f0?branch=rawhide.

systemd-devel was added in
https://src.fedoraproject.org/rpms/avahi/c/9391e1eeb38892f1b21ab71edb4f2f926f98601b?branch=rawhide.

%{_sysconfdir}/dbus-1/system.d/avahi-dbus.conf was replaced with %{_datadir}/dbus-1/system.d/avahi-dbus.conf in
https://src.fedoraproject.org/rpms/avahi/c/2858c1b8d7ec8b67fdf3389e04f2f05b19ab8e0e?branch=rawhide.