### PR TITLE
ci: actually send queries to port 5353 on FreeBSD (and Alpine)

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -84,8 +84,8 @@ systemd-run -u avahi-test-publish-address avahi-publish -fvaR  "$h" "$ipv4addr"
 
 # ::1 isn't here due to https://github.com/avahi/avahi/issues/574
 for s in 127.0.0.1 224.0.0.1 ff02::fb; do
-   drill "@$s" -p5353 "$h" ANY
-   drill "@$s" -p5353 "_services._dns-sd._udp.local" ANY
+   drill -p5353 "@$s" "$h" ANY
+   drill -p5353 "@$s" "_services._dns-sd._udp.local" ANY
 done
 
 dbus_call ResolveAddress -1 -1 "$ipv4addr" 0


### PR DESCRIPTION
On FreeBSD (and Alpine) drill ignores the `-p` argument when it isn't passed first and sends its queries to port 53:
```
21:15:52.906120 IP localhost.41359 > localhost.53: 38663+ ANY? 0a12059c0953.local. (36)
21:15:52.906222 IP localhost > localhost: ICMP localhost udp port 53 unreachable, length 72
```
With this patch applied it now works on the FreeBSD CI with the loopback interface:
```
+ drill -p5353 @127.0.0.1 freebsd.local ANY
;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 36178
;; flags: qr aa ; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 0
;; QUESTION SECTION:
;; freebsd.local.	IN	ANY
;; ANSWER SECTION:
freebsd.local.	10	IN	AAAA	::1
freebsd.local.	10	IN	A	127.0.0.1
freebsd.local.	10	IN	HINFO	"AMD64" "FREEBSD"
;; AUTHORITY SECTION:
;; ADDITIONAL SECTION:
;; Query time: 7 msec
;; SERVER: 127.0.0.1
;; WHEN: Thu Nov 13 22:05:03 2025
;; MSG SIZE  rcvd: 101
```

Partly addresses https://github.com/avahi/avahi/issues/751