### PR TITLE
ci: send queries to the mDNS IPv4 link-local multicast address

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -83,7 +83,7 @@ avahi-resolve -v -a "$ipv6addr"
 systemd-run -u avahi-test-publish-address avahi-publish -fvaR  "$h" "$ipv4addr"
 
 # ::1 isn't here due to https://github.com/avahi/avahi/issues/574
-for s in 127.0.0.1 224.0.0.1 ff02::fb; do
+for s in 127.0.0.1 224.0.0.251 ff02::fb; do
    drill -p5353 "@$s" "$h" ANY
    drill -p5353 "@$s" "_services._dns-sd._udp.local" ANY
 done


### PR DESCRIPTION
224.0.0.1 works in some cases but the test is actually supposed to test 224.0.0.251.

With this patch applied the queries reach avahi on the FreeBSD CI:
```
2025-11-14T06:58:42.3291638Z + drill -p5353 @224.0.0.251 freebsd.local ANY
2025-11-14T06:58:42.3341737Z ;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 43649
2025-11-14T06:58:42.3343232Z ;; flags: qr aa ; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0
2025-11-14T06:58:42.3344071Z ;; QUESTION SECTION:
2025-11-14T06:58:42.3344459Z ;; freebsd.local.	IN	ANY
2025-11-14T06:58:42.3344741Z
2025-11-14T06:58:42.3344866Z ;; ANSWER SECTION:
2025-11-14T06:58:42.3345220Z freebsd.local.	10	IN	A	10.0.2.15
2025-11-14T06:58:42.3345683Z freebsd.local.	10	IN	HINFO	"AMD64" "FREEBSD"
2025-11-14T06:58:42.3346018Z
2025-11-14T06:58:42.3346154Z ;; AUTHORITY SECTION:
2025-11-14T06:58:42.3346799Z
2025-11-14T06:58:42.3346937Z ;; ADDITIONAL SECTION:
2025-11-14T06:58:42.3347162Z
2025-11-14T06:58:42.3347300Z ;; Query time: 0 msec
2025-11-14T06:58:42.3347878Z ;; SERVER: 224.0.0.251
2025-11-14T06:58:42.3348194Z ;; WHEN: Fri Nov 14 06:58:42 2025
2025-11-14T06:58:42.3348542Z ;; MSG SIZE  rcvd: 73
```

(It would probably make sense to switch to scapy at some point)

Partly addresses https://github.com/avahi/avahi/issues/751.