### PR TITLE
ci: run the smoke tests on ubuntu-24.04-arm as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,14 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     concurrency:
-      group: ${{ github.workflow }}-${{ toJSON(matrix.env) }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ toJSON(matrix.env) }}-${{ matrix.runner }}-${{ github.ref }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
         env:
           - { CC: "gcc", DISTCHECK: "true", VALGRIND: "true" }
           - { CC: "gcc", ASAN_UBSAN: "true" }


### PR DESCRIPTION
There were issues that could have been easily caught by running tests/fuzz targets on aarch64 (for example
99eae8dd997233d3e7cff7254275d5abcaae53a9) so it makes sense to start running the smoke tests there now that ubuntu-24.04-arm is available.