### PR TITLE
ci: advertise A, AAAA and A/AAAA RRs for avahi-test

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -234,8 +234,12 @@ EOL
             s/^\(publish-hinfo=\).*/\1yes/;
         ' avahi-daemon/avahi-daemon.conf
 
-        printf "2001:db8::1 static-host-test.local\n" >>avahi-daemon/hosts
-        printf "192.0.2.1 static-host-test.local\n" >>avahi-daemon/hosts
+        cat <<'EOL' >>avahi-daemon/hosts
+192.0.2.1 ipv4.local
+2001:db8::1 ipv6.local
+192.0.2.2 ipv46.local
+2001:db8::2 ipv46.local
+EOL
 
         $MAKE install
         ldconfig


### PR DESCRIPTION
Now that https://github.com/avahi/nss-mdns/pull/107 is merged it should be fine to run it under Valgrind.