### PR TITLE
docs: mention 90 day disclosure timeline

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,3 +1,5 @@
 # Reporting Security Issues
 
 To report a security issue, please use the ["Report a Vulnerability"](https://github.com/avahi/avahi/security/advisories/new) tab.
+
+The avahi project follows a 90 day disclosure timeline.


### PR DESCRIPTION
to make it clear that the avahi project doesn't sit on reports forever. There was already some confusion regarding that part.