### PR TITLE
ci: run nss-test under Valgrind on FreeBSD

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -173,11 +173,7 @@ run_nss_tests() {
     for h in ipv4.local ipv6.local ipv46.local; do
         run "$NSS_MDNS_BUILD_DIR/avahi-test" "$h"
 
-        # nss-test fails under Valgrind on FreeBSD
-        # https://github.com/avahi/nss-mdns/issues/105
-        if [[ "$OS" != FreeBSD || "$VALGRIND" != true ]]; then
-            run "$NSS_MDNS_BUILD_DIR/nss-test" "$h"
-        fi
+        run "$NSS_MDNS_BUILD_DIR/nss-test" "$h"
 
         if LD_PRELOAD="" avahi-daemon -c; then
             run getent hosts "$h"


### PR DESCRIPTION
Now that https://github.com/avahi/nss-mdns/pull/110 is merged the test can be run under Valgrind on FreeBSD as well.