### PR TITLE
ci: run `make distcheck` from nss-mdns on FreeBSD

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -136,9 +136,7 @@ install_nss_mdns() {
         exit 1
     fi
 
-    # make distcheck fails on FreeBSD
-    # https://github.com/avahi/nss-mdns/issues/103
-    if [[ "$DISTCHECK" == true && "$OS" != FreeBSD ]]; then
+    if [[ "$DISTCHECK" == true ]]; then
         $MAKE distcheck V=1
     fi
 


### PR DESCRIPTION
It can be run now that https://github.com/avahi/nss-mdns/issues/103 is addressed.