### PR TITLE
check-nss.c: Properly detect the mdns NSS module on FreeBSD

### DIFF
--- a/avahi-client/check-nss.c
+++ b/avahi-client/check-nss.c
@@ -32,11 +32,19 @@ int avahi_nss_support(void) {
     int b = 0;
 
 #ifdef HAVE_DLOPEN
+#ifndef __FreeBSD__
     static const char * const libs[] = {
         "libnss_mdns.so.2",
         "libnss_mdns4.so.2",
         "libnss_mdns6.so.2",
         NULL };
+#else
+    static const char * const libs[] = {
+        "nss_mdns.so.1",
+        "nss_mdns4.so.1",
+        "nss_mdns6.so.1",
+        NULL };
+#endif
 
     const char * const *l;
 


### PR DESCRIPTION
FreeBSD NSS modules do not have the "lib" prefix and their version suffix is hardcoded to .1

Fixes #775

This is inspired by the patch we already have in Ports: https://github.com/freebsd/freebsd-ports/blob/5a57344b49bb79c26ea74a42aefeeb3e51a71305/net/avahi-app/files/patch-avahi-client_check-nss.c#L1