### PR TITLE
libdns_sd: Avoid the race reported by ThreadSanitizer

### DIFF
--- a/avahi-compat-libdns_sd/compat.c
+++ b/avahi-compat-libdns_sd/compat.c
@@ -310,7 +310,6 @@ static void * thread_func(void *data) {
     pthread_sigmask(SIG_BLOCK, &mask, NULL);
 
     sdref->thread = pthread_self();
-    sdref->thread_running = 1;
 
     for (;;) {
         char command;


### PR DESCRIPTION
The thread_running field is set to 1 twice - from the main thread after calling pthread_create() and from the spawned thread. This isn't really a race, because we're setting it to the same value, but these concurrent writes confuse ThreadSanitizer.