### PR TITLE
ci: switch ClusterFuzzLite from Ubuntu 20.04 to Ubuntu 24.04

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder:v1
+FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 ENV MERGE_WITH_OSS_FUZZ_CORPORA=yes
 COPY . $SRC/avahi
 WORKDIR $SRC/avahi

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+base_os_version: ubuntu-24-04

--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -21,6 +21,10 @@ jobs:
       matrix:
         sanitizer: [address, undefined, memory]
     steps:
+    - name: Repository checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Build Fuzzers
       id: build
       uses: google/clusterfuzzlite/actions/build_fuzzers@v1


### PR DESCRIPTION
by using the `base_os_version` field and switching to the ubuntu-24-04
base builder image. The checkout action is needed to get it to pivot to
Ubuntu 24.04 by analogy with what CIFuzz does. Without that the action
can't find project.yaml, falls back to `legacy` and keeps using Ubuntu
20.04.

See also https://github.com/google/clusterfuzzlite/pull/146