### PR TITLE
ci: roll out Alpine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,8 +80,27 @@ jobs:
           architecture: 'x86_64'
           environment_variables: ASAN_UBSAN CC DISTCHECK VALGRIND
           run: |
-            # - Use GNU make instead of BSD one
-            export MAKE="gmake"
-
             sudo -E .github/workflows/build.sh install-build-deps-FreeBSD
             sudo -E .github/workflows/build.sh build
+
+  alpine:
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ toJSON(matrix.env) }}-${{ github.ref }}-alpine
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - { CC: "gcc", VALGRIND: "true", DISTCHECK: "true" }
+          - { CC: "clang", VALGRIND: "false", DISTCHECK: "false" }
+    env: ${{ matrix.env }}
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v4
+      - uses: jirutka/setup-alpine@v1.4.1
+      - run: |
+            apk add bash
+            .github/workflows/build.sh install-build-deps-Alpine
+            .github/workflows/build.sh build
+        shell: alpine.sh --root {0}

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -9,18 +9,18 @@ export NSS_MDNS_BUILD_DIR=
 export ASAN_RT_PATH=
 
 runstatedir=/run
-if [[ "$OS" == FreeBSD ]]; then
+if [[ "$OS" == freebsd ]]; then
     runstatedir=/var/run
 fi
 sysconfdir=/etc
-if [[ "$OS" == FreeBSD ]]; then
+if [[ "$OS" == freebsd ]]; then
     sysconfdir=/usr/local/etc
 fi
 avahi_daemon_runtime_dir="$runstatedir/avahi-daemon"
 avahi_socket="$avahi_daemon_runtime_dir/socket"
 
 dump_journal() {
-    if [[ "$OS" == FreeBSD ]]; then
+    if [[ "$OS" == freebsd ]]; then
         cat /var/log/messages
     else
         journalctl --sync
@@ -72,7 +72,7 @@ skip_nss_mdns() {
 
     # -shared-libasan doesn't work on FreeBSD. It bails out with
     # AddressSanitizer: CHECK failed: asan_posix.cpp:121 "((0)) == ((pthread_key_create(&tsd_key, destructor)))" (0x0, 0x4e) (tid=100146)
-    if [[ "$OS" == FreeBSD && "$ASAN_UBSAN" == true ]]; then
+    if [[ "$OS" == freebsd && "$ASAN_UBSAN" == true ]]; then
         return 0
     fi
 
@@ -98,7 +98,7 @@ install_nss_mdns() {
     pushd "$NSS_MDNS_BUILD_DIR"
     autoreconf -ivf
     configure_args=("--enable-tests")
-    if [[ "$OS" == FreeBSD ]]; then
+    if [[ "$OS" == freebsd ]]; then
         configure_args+=(
             "--prefix=/usr/local"
             "--runstatedir=/var/run"
@@ -205,7 +205,7 @@ done
 
 run_nss_tests
 
-if [[ "$OS" == FreeBSD ]]; then
+if [[ "$OS" != ubuntu ]]; then
     avahi-daemon -D
     avahi-dnsconfd -D
 else
@@ -217,7 +217,7 @@ run ./avahi-client/client-test
 (cd avahi-daemon && run ./ini-file-parser-test)
 run ./avahi-compat-howl/address-test
 
-if [[ "$OS" != FreeBSD || "$VALGRIND" != true ]]; then
+if [[ "$OS" != freebsd || "$VALGRIND" != true ]]; then
     run ./avahi-compat-libdns_sd/null-test
 fi
 
@@ -230,7 +230,7 @@ done
 
 run ./examples/glib-integration
 
-if [[ "$OS" != FreeBSD ]]; then
+if [[ "$OS" != freebsd ]]; then
     run ./tests/c-plus-plus-test
 fi
 
@@ -248,7 +248,7 @@ cat <<'EOL' >"$sysconfdir/avahi/services/test-notifications.service"
 EOL
 drill -p5353 @127.0.0.1 test-notifications._qotd._tcp.local ANY
 
-if [[ "$OS" == FreeBSD ]]; then
+if [[ "$OS" != ubuntu ]]; then
     run avahi-dnsconfd --kill
     run avahi-daemon --kill
     exit 0


### PR DESCRIPTION
to cover musl-based environments to make sure it's more or less releasable there. It compiles avahi, runs `make check`, `make distcheck` and `make valgrind` for now. os-release is now used to tell the environments apart because uname (with Linux and FreeBSD) doesn't cut it anymore.