### PR TITLE
ci: run more tests on Alpine

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -96,9 +96,9 @@ case "$1" in
         pkg remove -fy avahi-app
         ;;
     install-build-deps-Alpine)
-        apk add autoconf automake clang coreutils dbus-dev drill expat-dev gcc g++ \
+        apk add autoconf automake clang coreutils dbus dbus-dev drill expat-dev gcc g++ \
             gdbm-dev gettext-dev git glib-dev gobject-introspection-dev gtk+3.0-dev \
-            gzip libdaemon-dev libevent-dev libtool make meson mono-dev musl-dev \
+            gzip libdaemon-dev libevent-dev libtool make meson mono-dev musl-dbg musl-dev \
             py3-dbus py3-gobject3-dev py3-setuptools python3-dev python3-gdbm \
             qt5-qtbase-dev socat tar valgrind xmltoman
 
@@ -298,16 +298,15 @@ EOL
         if [[ "$OS" == alpine ]]; then
             addgroup -S avahi
             adduser -S -G avahi avahi
+            syslogd
+            mkdir /run/dbus
+            dbus-daemon --system --fork
         elif [[ "$OS" == freebsd ]]; then
             hostname freebsd
             service dbus onerestart
         else
             adduser --system --group avahi
             systemctl reload dbus
-        fi
-
-        if [[ "$OS" == alpine ]]; then
-            exit 0
         fi
 
         if ! .github/workflows/smoke-tests.sh; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,10 @@ jobs:
 
   alpine:
     runs-on: ubuntu-24.04
+    container:
+      image: alpine
+      env: ${{ matrix.env }}
+      options: --init
     concurrency:
       group: ${{ github.workflow }}-${{ toJSON(matrix.env) }}-${{ github.ref }}-alpine
       cancel-in-progress: true
@@ -94,13 +98,10 @@ jobs:
         env:
           - { CC: "gcc", VALGRIND: "true", DISTCHECK: "true" }
           - { CC: "clang", VALGRIND: "false", DISTCHECK: "false" }
-    env: ${{ matrix.env }}
     steps:
       - name: Repository checkout
         uses: actions/checkout@v4
-      - uses: jirutka/setup-alpine@v1.4.1
       - run: |
-            apk add bash
-            .github/workflows/build.sh install-build-deps-Alpine
-            .github/workflows/build.sh build
-        shell: alpine.sh --root {0}
+          apk add bash
+          .github/workflows/build.sh install-build-deps-Alpine
+          .github/workflows/build.sh build

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -20,7 +20,7 @@ avahi_daemon_runtime_dir="$runstatedir/avahi-daemon"
 avahi_socket="$avahi_daemon_runtime_dir/socket"
 
 dump_journal() {
-    if [[ "$OS" == freebsd ]]; then
+    if [[ "$OS" != ubuntu ]]; then
         cat /var/log/messages
     else
         journalctl --sync
@@ -215,7 +215,10 @@ fi
 
 run ./avahi-client/client-test
 (cd avahi-daemon && run ./ini-file-parser-test)
-run ./avahi-compat-howl/address-test
+
+if [[ "$OS" != alpine ]]; then
+    run ./avahi-compat-howl/address-test
+fi
 
 if [[ "$OS" != freebsd || "$VALGRIND" != true ]]; then
     run ./avahi-compat-libdns_sd/null-test


### PR DESCRIPTION
by switching from chroot to containers with init, syslogd and dbus. It hasn't gotten to the point where it can catch things like https://github.com/avahi/avahi/issues/763 with dfuzzer and Valgrind but those things are run elsewhere for now.