### PR TITLE
ci: install curl for radamsa

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -75,7 +75,7 @@ case "$1" in
 
         apt-get install -y libtool-bin valgrind socat ldnsutils
 
-        apt-get install -y libglib2.0-dev meson
+        apt-get install -y libglib2.0-dev meson curl
 
         apt-get install -y check
         install_dfuzzer


### PR DESCRIPTION
Base images where this test is also run don't come with curl and install_radamsa fails with
```
/bin/sh: 1: wget: not found
/bin/sh: 1: curl: not found
make[1]: *** [Makefile:34: ol.c] Error 127
make[1]: Leaving directory '/root/avahi/radamsa'
make: *** [Makefile:23: radamsa.c] Error 2
```