### PR TITLE
ci: trim distro checks

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -205,7 +205,7 @@ done
 
 run_nss_tests
 
-if [[ "$OS" != ubuntu ]]; then
+if [[ "$WITH_SYSTEMD" == false ]]; then
     avahi-daemon -D
     avahi-dnsconfd -D
 else
@@ -251,7 +251,7 @@ cat <<'EOL' >"$sysconfdir/avahi/services/test-notifications.service"
 EOL
 drill -p5353 @127.0.0.1 test-notifications._qotd._tcp.local ANY
 
-if [[ "$OS" != ubuntu ]]; then
+if [[ "$WITH_SYSTEMD" == false ]]; then
     run avahi-dnsconfd --kill
     run avahi-daemon --kill
     exit 0


### PR DESCRIPTION
In some cases it doesn't matter much whether it's Ubuntu or FreeBSD. What matters is whether the unit files are expected to be generated. With this patch applied it should be easier to run the smoke tests downstream outside of the upstream CI with its specific distros.

Also systemd-dev in installed explicitly because base images don't come with it either.