### PR TITLE
ci: various tweaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 2
+    cooldown:
+      default-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,9 @@ jobs:
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
       - run: sudo -E .github/workflows/build.sh install-build-deps
       - run: sudo -E .github/workflows/build.sh build
   coverage:
@@ -47,11 +49,13 @@ jobs:
       COVERAGE: "true"
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
       - run: sudo -E .github/workflows/build.sh install-build-deps
       - run: sudo -E .github/workflows/build.sh build
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: ./coverage.info
@@ -72,8 +76,10 @@ jobs:
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v6
-      - uses: cross-platform-actions/action@v0.29.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - uses: cross-platform-actions/action@46e8d7fb25520a8d6c64fd2b7a1192611da98eda # v0.30.0
         with:
           operating_system: 'freebsd'
           version: '14.3'
@@ -100,7 +106,9 @@ jobs:
           - { CC: "clang", VALGRIND: "false", DISTCHECK: "false" }
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
       - run: |
           apk add bash
           .github/workflows/build.sh install-build-deps-Alpine

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -50,7 +50,7 @@ jobs:
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}
       - name: Upload Crash
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure() && steps.build.outcome == 'success'
         with:
           name: ${{ matrix.sanitizer }}-${{ matrix.architecture }}-artifacts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,10 +34,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
       with:
         languages: ${{ matrix.language }}
 
@@ -46,4 +48,4 @@ jobs:
     - run: .github/workflows/build.sh build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -16,7 +16,9 @@ jobs:
     if: github.repository == 'avahi/avahi'
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - run: sudo -E .github/workflows/build.sh install-build-deps
 

--- a/.github/workflows/differential-shellcheck.yaml
+++ b/.github/workflows/differential-shellcheck.yaml
@@ -25,19 +25,20 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - id: ShellCheck
         name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        uses: redhat-plumbers-in-action/differential-shellcheck@d965e66ec0b3b2f821f75c8eff9b12442d9a7d1e # v5.5.6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - if: ${{ always() }}
         name: Upload artifact with ShellCheck defects in SARIF format
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: Differential ShellCheck SARIF
           path: ${{ steps.ShellCheck.outputs.sarif }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,12 +19,13 @@ jobs:
 
     steps:
       - name: Repo checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Lint
-        uses: super-linter/super-linter/slim@v8.3.0
+        uses: super-linter/super-linter/slim@502f4fe48a81a392756e173e39a861f8c8efe056 # v8.3.0
         env:
           MULTI_STATUS: false
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
The cooldown option is set to prevent Dependabot from attempting to switch to new releases as soon as they are available: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-. It should prevent it from recommending releases that haven't been tested yet.

The actions are pinned to their full-length commit SHAs. It's still the most reliable way to make sure that tags aren't moved (immutable releases are supposed to improve that but they aren't turned on everywhere). CIFuzz and CFLite aren't pinned because they roll forward by design.

The persist-credentials option is set to false because it's the most sensible default. It got improved recently
(https://github.com/orgs/community/discussions/179107#discussioncomment-14906259) but still. That being said all the actions are read-only mostly (apart from a couple of places where security-events are writable to upload SARIF analysis results) so it's a cosmetic change.