### PR TITLE
ci: use concurrency everywhere

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/differential-shellcheck.yaml
+++ b/.github/workflows/differential-shellcheck.yaml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,3 +30,6 @@ jobs:
           MULTI_STATUS: false
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: true
+          LINTER_RULES_PATH: '.github'
+          GITHUB_ACTIONS_ZIZMOR_CONFIG_FILE: 'zizmor.yml'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,15 @@
+rules:
+  unpinned-images:
+    ignore:
+      # It would be great to pin images in workflows but Dependabot
+      # can't update them unfortunately:
+      # https://github.com/dependabot/dependabot-core/issues/5819
+      - build.yml
+  unpinned-uses:
+    config:
+      policies:
+        # CIFuzz and ClusterFuzzLite can't be meaninguflly pinned to
+        # their full-length commit SHAs so they just roll forward.
+        'google/clusterfuzzlite/*': ref-pin
+        'google/oss-fuzz/*': ref-pin
+        '*': hash-pin


### PR DESCRIPTION
differential-shellcheck is short-lived so it doesn't matter much whether it's cancelled or not but it's still possible to force-push things fast enough to get it to run in parallel and that's not desirable.

coverity is normally scheduled once a day so it doesn't matter much whether it's cancelled properly or not but when it's tested in, say, PRs it still makes sense to cancel it correctly.

zizmor is turned on in addition to actionlint to catch various things
when PRs are opened.