### PR TITLE
ci: trim one more distro check

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -21,7 +21,7 @@ avahi_daemon_runtime_dir="$runstatedir/avahi-daemon"
 avahi_socket="$avahi_daemon_runtime_dir/socket"
 
 dump_journal() {
-    if [[ "$OS" != ubuntu ]]; then
+    if [[ "$WITH_SYSTEMD" == false ]]; then
         cat /var/log/messages
     else
         journalctl --sync


### PR DESCRIPTION
It doesn't matter there whether it's Ubuntu, Alpine or FreeBSD. What matters is whether the unit files are expected to be generated and tested in the corresponding environment.

It's a follow-up to 7455194ed46f8b392830cf541466a01b47ae6d09