### PR TITLE
docs: bring CodingStyle from the long gone Wiki

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Coding Style
+
+We mostly follow the [coding style guidelines of the PulseAudio project](https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/Developer/CodingStyle/). However, there are a few deviations:
+
+- Avahi uses GLib style CamelCase names for structs.
+- Our prefix for functions is `avahi_` and not `pa_`.
+- We have no `pa_assert()` counterpart. Use standard libc `assert()` instead.
+- We lack a `pa_assert_se()` counterpart. Use libc `assert()`, but make sure your code still works when NDEBUG is defined.


### PR DESCRIPTION
It was brought from
https://web.archive.org/web/20160504114856/http://avahi.org/wiki/CodingStyle