### PR TITLE
ci: run avahi-daemon under Valgrind everywhere

### DIFF
--- a/.github/workflows/avahi-daemon.supp
+++ b/.github/workflows/avahi-daemon.supp
@@ -1,0 +1,20 @@
+{
+   libdaemon-stdin-stdout-stderr-dev-null
+   CoreError:FdNotClosed
+   fun:dup2
+   ...
+   fun:daemon_fork
+   fun:main
+}
+
+{
+   libdaemon-syslog
+   CoreError:FdNotClosed
+   fun:socket
+   ...
+   fun:daemon_log
+   fun:log_function
+   fun:avahi_log_ap
+   ...
+   fun:main
+}

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -239,9 +239,9 @@ printf "%s\n" "<$1> <$2> <$3> <$4>" | logger
 EOL
 
         if [[ "$VALGRIND" == true && "$WITH_SYSTEMD" == true ]]; then
-            sed -i.bak '
-                /^ExecStart/s/=/=valgrind --leak-check=full --track-origins=yes --track-fds=yes --error-exitcode=1 /
-            ' avahi-daemon/avahi-daemon.service
+            sed -i.bak "
+                /^ExecStart/s!=!=valgrind -s --suppressions='$(pwd)/.github/workflows/avahi-daemon.supp' --leak-check=full --track-origins=yes --track-fds=yes --error-exitcode=1 !
+            " avahi-daemon/avahi-daemon.service
             sed -i.bak '/^ExecStart=/s/$/ --no-chroot --no-drop-root --no-proc-title/' avahi-daemon/avahi-daemon.service
 
             sed -i.bak '


### PR DESCRIPTION
Up until this point avahi-daemon was run under Valgrind on Ubuntu only because the output of Valgrind and its exit code were tracked only there.

On FreeBSD and Alpine the output of Valgrind is forwarded to /dev/null by default (because of libdaemon forwarding stderr there in daemon_fork) so Valgrind is run with --log-file instead and all the errors are looked for there. The suppression file is added to suppress reports where Valgrind complains about 4 file descriptors handled by libdaemon: stdin, stdout, stderr and the syslog socket. It's needed on Ubuntu too but Valgrind isn't new enough on Ubuntu 24.04 on the CI upstream so it doesn't fail with --track-fds=yes yet (even though it complains about the syslog fd).