### PR TITLE
ci: install gdb and systemd-coredump explicitly

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -107,6 +107,7 @@ case "$1" in
         apt-get install -y mono-mcs monodoc-base libmono-posix4.0-ci
 
         apt-get install -y libtool-bin valgrind socat ldnsutils
+        apt-get install -y gdb systemd-coredump
 
         apt-get install -y libglib2.0-dev meson curl
 


### PR DESCRIPTION
they are available on the CI upstream on GitHub but they aren't necessarily included in base images everywhere.

It's a follow-up to 31ef44e0143a2f4421451d086271147e5f95aeb0.