### PR TITLE
Explicitly cast enums to fix GCC warnings in avahi-gobject

### DIFF
--- a/avahi-gobject/ga-client.c
+++ b/avahi-gobject/ga-client.c
@@ -223,7 +223,7 @@ static void _avahi_client_cb(AvahiClient * c, AvahiClientState state, void *data
         self->avahi_client = c;
 
     g_assert(c == self->avahi_client);
-    priv->state = state;
+    priv->state = (GaClientState) state;
     g_signal_emit(self, signals[STATE_CHANGED],
                   detail_for_state(state), state);
 }
@@ -245,7 +245,7 @@ gboolean ga_client_start_in_context(GaClient * client, GMainContext * context, G
     priv->poll = avahi_glib_poll_new(context, G_PRIORITY_DEFAULT);
 
     aclient = avahi_client_new(avahi_glib_poll_get(priv->poll),
-                               priv->flags,
+                               (AvahiClientFlags) priv->flags,
                                _avahi_client_cb, client, &aerror);
     if (aclient == NULL) {
         if (error != NULL) {

--- a/avahi-gobject/ga-entry-group.c
+++ b/avahi-gobject/ga-entry-group.c
@@ -219,7 +219,7 @@ static void _avahi_entry_group_cb(AvahiEntryGroup * g,
         priv->group = g;
 
     g_assert(g == priv->group);
-    priv->state = state;
+    priv->state = (GaEntryGroupState) state;
     g_signal_emit(self, signals[STATE_CHANGED],
                   detail_for_state(state), state);
 }


### PR DESCRIPTION
GCC complains about implicit enum conversions. This PR fixes this by casting them explicitly, which also improves code readability.

This is part of #820.