### PR TITLE
Add missing break in ga_client_get_property to prevent incorrect warnings in avahi-gobject

### DIFF
--- a/avahi-gobject/ga-client.c
+++ b/avahi-gobject/ga-client.c
@@ -103,6 +103,7 @@ static void ga_client_get_property(GObject * object,
             break;
         case PROP_FLAGS:
             g_value_set_enum(value, priv->flags);
+            break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
             break;


### PR DESCRIPTION
GCC complained about an implicit fallthrough, which looks like a missing break statement. This is a bug that just caused incorrect warning messages, without affecting behavior.

This is part of #820.