### PR TITLE
fuzz: decouple the build script from OSS-Fuzz a bit

### DIFF
--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -102,7 +102,7 @@ for f in fuzz/fuzz-*.c; do
 
     # CXXFLAGS have to be split
     # shellcheck disable=SC2086
-    $CXX $CXXFLAGS \
+    "${LINK_WITH:-$CXX}" $CXXFLAGS \
         "$fuzz_target.o" \
         -o "$OUT/$fuzz_target" \
         $LIB_FUZZING_ENGINE \


### PR DESCRIPTION
On OSS-Fuzz `$CXX` has to be used as a linker even for C projects: https://google.github.io/oss-fuzz/getting-started/new-project-guide/#Requirements. It's all well and good but when the script is run outside of OSS-Fuzz and depending on what `$LIB_FUZZING_ENGINE` is `$CXX` can confuse various scripts/wrappers collectiong coverage or emitting LLVM bitcode for KLEE-adjacent testing and so on. The script still uses `$CXX` by default but allows tweaking it by passing the `LINK_WITH` environment variable.