### PR TITLE
man: Convert tabs to spaces, administrative only

### DIFF
--- a/man/avahi-autoipd.8.xml.in
+++ b/man/avahi-autoipd.8.xml.in
@@ -23,12 +23,12 @@
 
   <manpage name="avahi-autoipd" section="8" desc="IPv4LL network address configuration daemon">
 
-	<synopsis>
+    <synopsis>
       <cmd>avahi-autoipd [<arg>options</arg>] <arg>interface</arg></cmd>
       <cmd>avahi-autoipd <opt>--kill</opt> <arg>interface</arg></cmd>
       <cmd>avahi-autoipd <opt>--refresh</opt> <arg>interface</arg></cmd>
       <cmd>avahi-autoipd <opt>--check</opt> <arg>interface</arg></cmd>
-	</synopsis>
+    </synopsis>
 
     <description>
       <p>avahi-autoipd implements IPv4LL, "Dynamic Configuration of
@@ -53,29 +53,29 @@
       <p><opt>route add default dev eth0 metric 99</opt></p>
 
       <p>See http://developer.apple.com/qa/qa2004/qa1357.html for more information.</p>
-	</description>
+    </description>
 
-	<options>
+    <options>
 
-	  <option>
-		<p><opt>-D | --daemonize</opt></p>
-		<optdesc><p>Daemonize after startup. Implies <opt>--syslog</opt>.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-D | --daemonize</opt></p>
+        <optdesc><p>Daemonize after startup. Implies <opt>--syslog</opt>.</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-k | --kill</opt></p>
-		<optdesc><p>Kill an already running avahi-autoipd on the specified network interface. (Equivalent to sending a SIGTERM)</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-k | --kill</opt></p>
+        <optdesc><p>Kill an already running avahi-autoipd on the specified network interface. (Equivalent to sending a SIGTERM)</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-r | --refresh</opt></p>
-		<optdesc><p>Tell an already running avahi-autoipd to re-announce the acquired IP address on the specified network interface. (Equivalent to sending a SIGHUP)</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-r | --refresh</opt></p>
+        <optdesc><p>Tell an already running avahi-autoipd to re-announce the acquired IP address on the specified network interface. (Equivalent to sending a SIGHUP)</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-c | --check</opt></p>
-		<optdesc><p>Return 0 as return code if avahi-autoipd is already running for the specified network interface.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-c | --check</opt></p>
+        <optdesc><p>Return 0 as return code if avahi-autoipd is already running for the specified network interface.</p></optdesc>
+      </option>
 
       <option>
         <p><opt>-s | --syslog</opt></p>
@@ -120,17 +120,17 @@
         title.</p></optdesc>
       </option>
 
-	  <option>
-		<p><opt>-h | --help</opt></p>
-		<optdesc><p>Show help.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-h | --help</opt></p>
+        <optdesc><p>Show help.</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-v | --version</opt></p>
-		<optdesc><p>Show version information.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-v | --version</opt></p>
+        <optdesc><p>Show version information.</p></optdesc>
+      </option>
 
-	</options>
+    </options>
 
     <section name="Files">
 
@@ -143,22 +143,22 @@
       <p><arg>SIGHUP</arg>: avahi-autoipd will re-announce the acquired IP address. (Same as <opt>--refresh</opt>)</p>
     </section>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-autoipd.action" section="8"/>, <manref name="dhclient" section="8"/>
-	  </p>
+      </p>
 
       <p>http://avahi.org/wiki/AvahiAutoipd documents how avahi-autoipd is best packaged and integrated into distributions.</p>
-	</section>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man" section="1"
-		  href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man" section="1"
+          href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/avahi-autoipd.action.8.xml.in
+++ b/man/avahi-autoipd.action.8.xml.in
@@ -23,9 +23,9 @@
 
   <manpage name="avahi-autoipd.action" section="8" desc="avahi-autoipd action script">
 
-	<synopsis>
+    <synopsis>
       <cmd>@pkgsysconfdir@/avahi-autoipd.action</cmd>
-	</synopsis>
+    </synopsis>
 
     <description>
       <p><file>avahi-autoipd.action</file> is the action script that
@@ -33,9 +33,9 @@
       avahi-autoipd or when it detected an IP address conflict. The
       script should add or remove the specified address from the
       specified network interface.</p>
-	</description>
+    </description>
 
-	<section name="Parameters">
+    <section name="Parameters">
 
       <option>
         <p><opt>argv[1]</opt> An event string: one of BIND, CONFLICT,
@@ -62,22 +62,22 @@
         <p><opt>argv[3]</opt> An IP address from the IPv4LL range.</p>
       </option>
 
-	</section>
+    </section>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-autoipd" section="8"/>, <manref name="dhclient-script" section="8"/>, <manref name="ip" section="8"/>, <manref name="ifconfig" section="8"/>
-	  </p>
-	</section>
+      </p>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man" section="1"
-		  href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man" section="1"
+          href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/avahi-bookmarks.1.xml.in
+++ b/man/avahi-bookmarks.1.xml.in
@@ -23,9 +23,9 @@
 
   <manpage name="avahi-bookmarks" section="1" desc="Web service showing mDNS/DNS-SD announced HTTP services using the Avahi daemon">
 
-	<synopsis>
+    <synopsis>
       <cmd>avahi-bookmarks</cmd>
-	</synopsis>
+    </synopsis>
 
     <description>
       <p>A web service for listing HTTP services that are announced
@@ -35,7 +35,7 @@
       type _http._tcp on the LAN. Point your browser to
       http://localhost:8080/ to make use of avahi-bookmarks.</p>
 
-	</description>
+    </description>
 
     <options>
       <option>
@@ -73,27 +73,27 @@
         <optdesc><p>The domain to browse for services in.</p></optdesc>
       </option>
 
-	  <option>
-		<p><opt>-h | --help</opt></p>
-		<optdesc><p>Show help</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-h | --help</opt></p>
+        <optdesc><p>Show help</p></optdesc>
+      </option>
 
     </options>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-browse" section="1"/>, <manref name="avahi-daemon" section="8"/>
-	  </p>
-	</section>
+      </p>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man" section="1"
-		  href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man" section="1"
+          href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/avahi-browse.1.xml.in
+++ b/man/avahi-browse.1.xml.in
@@ -23,41 +23,41 @@
 
   <manpage name="avahi-browse" section="1" desc="Browse for mDNS/DNS-SD services using the Avahi daemon">
 
-	<synopsis>
+    <synopsis>
       <cmd>avahi-browse [<arg>options</arg>] <arg>service-type</arg></cmd>
       <cmd>avahi-browse [<arg>options</arg>] <opt>--all</opt></cmd>
       <cmd>avahi-browse [<arg>options</arg>] <opt>--browse-domains</opt></cmd>
       <cmd>avahi-browse [<arg>options</arg>] <opt>--dump-db</opt></cmd>
       <cmd>avahi-browse-domains [<arg>options</arg>]</cmd>
-	</synopsis>
+    </synopsis>
 
     <description>
       <p>Browse for mDNS/DNS-SD network services and browsing domains using the Avahi daemon.</p>
 
-	</description>
+    </description>
 
-	<options>
+    <options>
 
       <p>Specify a DNS-SD service type (e.g. _http._tcp) to browse for
       on the command line, or <opt>-a</opt> to browse for all
       available service types. Items that appear on the network are prefixed with "+", items that disappear are prefixed with "-". If <opt>--resolve</opt> is passed items that are resolved are prefixed with "=".</p>
 
       <option>
-		<p><opt>-a | --all</opt></p>
-		<optdesc><p>Browse for all service types registered on the LAN, not just the one specified on the command line.</p></optdesc>
-	  </option>
+        <p><opt>-a | --all</opt></p>
+        <optdesc><p>Browse for all service types registered on the LAN, not just the one specified on the command line.</p></optdesc>
+      </option>
 
       <option>
         <p><opt>-D | --browse-domains</opt></p>
         <optdesc><p>Browse for browsing domains instead for services. avahi-browse-domains is equivalent to avahi-browse --browse-domains</p></optdesc>
       </option>
 
- 	  <option>
-		<p><opt>-d | --domain=</opt> <arg>DOMAIN</arg></p>
+      <option>
+        <p><opt>-d | --domain=</opt> <arg>DOMAIN</arg></p>
         <optdesc><p>Browse in the specified domain. If omitted
         avahi-browse will browse in the default browsing domain
         (usually: local)</p></optdesc>
-	  </option>
+      </option>
 
       <option>
         <p><opt>-v | --verbose</opt></p>
@@ -79,57 +79,57 @@
         <optdesc><p>Ignore local services, show only remote services.</p></optdesc>
       </option>
 
-	  <option>
-		<p><opt>-r | --resolve</opt></p>
-		<optdesc><p>Automatically resolve services found.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-r | --resolve</opt></p>
+        <optdesc><p>Automatically resolve services found.</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-f | --no-fail</opt></p>
-		<optdesc><p>Don't fail if the daemon is not found running. Instead, wait until it appears. If it disconnects, try to reconnect.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-f | --no-fail</opt></p>
+        <optdesc><p>Don't fail if the daemon is not found running. Instead, wait until it appears. If it disconnects, try to reconnect.</p></optdesc>
+      </option>
 
-	  <option>
+      <option>
                 <p><opt>-p | --parsable</opt></p>
-		<optdesc><p>Make output easily parsable for usage in scripts. If enabled fields are separated by semicolons (;), service names are escaped. It is recommended to combine this with <opt>--no-db-lookup</opt>.</p></optdesc>
-	  </option>
+        <optdesc><p>Make output easily parsable for usage in scripts. If enabled fields are separated by semicolons (;), service names are escaped. It is recommended to combine this with <opt>--no-db-lookup</opt>.</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-k | --no-db-lookup</opt></p>
-		<optdesc><p>Don't lookup services types in service type database.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-k | --no-db-lookup</opt></p>
+        <optdesc><p>Don't lookup services types in service type database.</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-b | --dump-db</opt></p>
-		<optdesc><p>Dump the service type database (may be combined with -k)</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-b | --dump-db</opt></p>
+        <optdesc><p>Dump the service type database (may be combined with -k)</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-h | --help</opt></p>
-		<optdesc><p>Show help.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-h | --help</opt></p>
+        <optdesc><p>Show help.</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-V | --version</opt></p>
-		<optdesc><p>Show version information.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-V | --version</opt></p>
+        <optdesc><p>Show version information.</p></optdesc>
+      </option>
 
-	</options>
+    </options>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-publish" section="1"/>, <manref name="avahi-resolve" section="1"/>, <manref name="avahi-daemon" section="8"/>
-	  </p>
-	</section>
+      </p>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man" section="1"
-		  href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man" section="1"
+          href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/avahi-daemon.8.xml.in
+++ b/man/avahi-daemon.8.xml.in
@@ -23,12 +23,12 @@
 
   <manpage name="avahi-daemon" section="8" desc="The Avahi mDNS/DNS-SD daemon">
 
-	<synopsis>
+    <synopsis>
       <cmd>avahi-daemon [<arg>options</arg>]</cmd>
       <cmd>avahi-daemon <opt>--kill</opt></cmd>
       <cmd>avahi-daemon <opt>--reload</opt></cmd>
       <cmd>avahi-daemon <opt>--check</opt></cmd>
-	</synopsis>
+    </synopsis>
 
     <description>
       <p>The Avahi mDNS/DNS-SD daemon implements Apple's Zeroconf
@@ -50,19 +50,19 @@
       <opt>publish-resolv-conf-dns-servers</opt> in
       <file>avahi-daemon.conf</file> the file
       <file>/etc/resolv.conf</file> will be read, too.</p>
-	</description>
+    </description>
 
-	<options>
+    <options>
 
-	  <option>
-		<p><opt>-f | --file=</opt> <arg>FILE</arg></p>
-		<optdesc><p>Specify the configuration file to read. (default: @pkgsysconfdir@/avahi-daemon.conf)</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-f | --file=</opt> <arg>FILE</arg></p>
+        <optdesc><p>Specify the configuration file to read. (default: @pkgsysconfdir@/avahi-daemon.conf)</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-D | --daemonize</opt></p>
-		<optdesc><p>Daemonize after startup. Implies <opt>--syslog</opt>.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-D | --daemonize</opt></p>
+        <optdesc><p>Daemonize after startup. Implies <opt>--syslog</opt>.</p></optdesc>
+      </option>
 
       <option>
         <p><opt>-s | --syslog</opt></p>
@@ -97,39 +97,39 @@
         title.</p></optdesc>
       </option>
 
-	  <option>
-		<p><opt>-k | --kill</opt></p>
-		<optdesc><p>Kill an already running avahi-daemon. (equivalent to sending a SIGTERM)</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-k | --kill</opt></p>
+        <optdesc><p>Kill an already running avahi-daemon. (equivalent to sending a SIGTERM)</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-r | --reload</opt></p>
-		<optdesc><p>Tell an already running avahi-daemon to reread
-		<file>/etc/resolv.conf</file> (in case you enabled
+      <option>
+        <p><opt>-r | --reload</opt></p>
+        <optdesc><p>Tell an already running avahi-daemon to reread
+        <file>/etc/resolv.conf</file> (in case you enabled
         <opt>publish-resolv-conf-dns-servers</opt> in
-		<file>avahi-daemon.conf</file>) and the files from
-		<file>@servicedir@/</file>. Please note that this will not
-		reload the
-		<file>@pkgsysconfdir@/avahi-daemon.conf</file>. (equivalent to
-		sending a SIGHUP)</p></optdesc>
-	  </option>
+        <file>avahi-daemon.conf</file>) and the files from
+        <file>@servicedir@/</file>. Please note that this will not
+        reload the
+        <file>@pkgsysconfdir@/avahi-daemon.conf</file>. (equivalent to
+        sending a SIGHUP)</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-c | --check</opt></p>
-		<optdesc><p>Return 0 as return code when avahi-daemon is already running.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-c | --check</opt></p>
+        <optdesc><p>Return 0 as return code when avahi-daemon is already running.</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-h | --help</opt></p>
-		<optdesc><p>Show help</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-h | --help</opt></p>
+        <optdesc><p>Show help</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-v | --version</opt></p>
-		<optdesc><p>Show version information </p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-v | --version</opt></p>
+        <optdesc><p>Show version information </p></optdesc>
+      </option>
 
-	</options>
+    </options>
 
     <section name="Files">
 
@@ -149,22 +149,22 @@
       <p><arg>SIGUSR1</arg>: avahi-daemon will dump local and remote cached resource record data to syslog.</p>
     </section>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-daemon.conf" section="5"/>, <manref name="avahi.hosts" section="5"/>, <manref name="avahi.service" section="5"/>, <manref name="avahi-dnsconfd" section="8"/>, <manref name="avahi-set-host-name" section="1"/>
-	  </p>
+      </p>
 
       <p>http://avahi.org/wiki/AvahiAndUnicastDotLocal documents the problems when using Avahi in a unicast DNS zone .local.</p>
-	</section>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man" section="1"
-		  href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man" section="1"
+          href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/avahi-daemon.conf.5.xml.in
+++ b/man/avahi-daemon.conf.5.xml.in
@@ -376,18 +376,18 @@
       <p><opt>rlimit-stack=</opt> Value in bytes for RLIMIT_STACK (maximum size of the process stack). Sensible values are heavily system dependent.</p>
     </option>
 
-		<option>
-			<p><opt>rlimit-nproc=</opt> Value for RLIMIT_NPROC (max number of
-				processes a user can launch). avahi-daemon forks of a helper process on
-				systems where <manref name="chroot" section="2"/> is available
-				therefore this value should not be set below 2. Note that while the
-				process limit only applies to this process, the total count of
-				processes to reach that limit includes all processes on the system with
-				the same UID, including any containers without UID remapping (such as
-				lxd containers with security.privileged=true).  The default
-				configuration of 3 was removed to prevent problems in this
-				scenario.</p>
-		</option>
+        <option>
+            <p><opt>rlimit-nproc=</opt> Value for RLIMIT_NPROC (max number of
+                processes a user can launch). avahi-daemon forks of a helper process on
+                systems where <manref name="chroot" section="2"/> is available
+                therefore this value should not be set below 2. Note that while the
+                process limit only applies to this process, the total count of
+                processes to reach that limit includes all processes on the system with
+                the same UID, including any containers without UID remapping (such as
+                lxd containers with security.privileged=true).  The default
+                configuration of 3 was removed to prevent problems in this
+                scenario.</p>
+        </option>
   </section>
 
   <section name="Authors">

--- a/man/avahi-discover.1.xml.in
+++ b/man/avahi-discover.1.xml.in
@@ -23,37 +23,37 @@
 
   <manpage name="avahi-discover" section="1" desc="Browse for mDNS/DNS-SD services using the Avahi daemon">
 
-	<synopsis>
+    <synopsis>
       <cmd>avahi-discover</cmd>
-	</synopsis>
+    </synopsis>
 
     <description>
       <p>Show a real-time graphical browse list for mDNS/DNS-SD
       network services running on the local LAN using the Avahi
       daemon.</p>
 
-	</description>
+    </description>
 
-	<options>
+    <options>
 
       <p>avahi-discover takes no command line arguments at the moment.</p>
 
     </options>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-daemon" section="8"/>, <manref name="avahi-browse" section="1"/>
-	  </p>
-	</section>
+      </p>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man" section="1"
-		  href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man" section="1"
+          href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/avahi-dnsconfd.8.xml.in
+++ b/man/avahi-dnsconfd.8.xml.in
@@ -23,12 +23,12 @@
 
   <manpage name="avahi-dnsconfd" section="8" desc="Unicast DNS server from mDNS/DNS-SD configuration daemon">
 
-	<synopsis>
+    <synopsis>
       <cmd>avahi-dnsconfd [<arg>options</arg>]</cmd>
       <cmd>avahi-dnsconfd <opt>--kill</opt></cmd>
       <cmd>avahi-dnsconfd <opt>--refresh</opt></cmd>
       <cmd>avahi-dnsconfd <opt>--check</opt></cmd>
-	</synopsis>
+    </synopsis>
 
     <description>
       <p>avahi-dnsconfd connects to a running avahi-daemon and runs
@@ -36,46 +36,46 @@
       server that is announced on the local LAN. This is useful for
       configuring unicast DNS servers in a DHCP-like fashion with
       mDNS.</p>
-	</description>
+    </description>
 
-	<options>
+    <options>
 
-	  <option>
-		<p><opt>-D | --daemonize</opt></p>
-		<optdesc><p>Daemonize after startup and redirect log messages to syslog.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-D | --daemonize</opt></p>
+        <optdesc><p>Daemonize after startup and redirect log messages to syslog.</p></optdesc>
+      </option>
 
       <option>
         <p><opt>-s | --syslog</opt></p>
         <optdesc><p>Log to syslog instead of STDERR. Implied by <opt>--daemonize</opt>.</p></optdesc>
       </option>
 
-	  <option>
-		<p><opt>-k | --kill</opt></p>
-		<optdesc><p>Kill an already running avahi-dnsconfd. (equivalent to sending a SIGTERM)</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-k | --kill</opt></p>
+        <optdesc><p>Kill an already running avahi-dnsconfd. (equivalent to sending a SIGTERM)</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-r | --refresh</opt></p>
-		<optdesc><p>Tell an already running avahi-dnsconfd to refresh the DNS server data. (equivalent to sending a SIGHUP)</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-r | --refresh</opt></p>
+        <optdesc><p>Tell an already running avahi-dnsconfd to refresh the DNS server data. (equivalent to sending a SIGHUP)</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-c | --check</opt></p>
-		<optdesc><p>Return 0 as return code when avahi-dnsconfd is already running.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-c | --check</opt></p>
+        <optdesc><p>Return 0 as return code when avahi-dnsconfd is already running.</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-h | --help</opt></p>
-		<optdesc><p>Show help</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-h | --help</opt></p>
+        <optdesc><p>Show help</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-v | --version</opt></p>
-		<optdesc><p>Show version information </p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-v | --version</opt></p>
+        <optdesc><p>Show version information </p></optdesc>
+      </option>
 
-	</options>
+    </options>
 
     <section name="Files">
 
@@ -88,20 +88,20 @@
       <p><arg>SIGHUP</arg>: avahi-dnsconfd will refresh the DNS server data.</p>
     </section>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-daemon" section="8"/>, <manref name="avahi-dnsconfd.action" section="8"/>
-	  </p>
-	</section>
+      </p>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man" section="1"
-		  href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man" section="1"
+          href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/avahi-dnsconfd.action.8.xml.in
+++ b/man/avahi-dnsconfd.action.8.xml.in
@@ -23,9 +23,9 @@
 
   <manpage name="avahi-dnsconfd.action" section="8" desc="avahi-dnsconfd action script">
 
-	<synopsis>
+    <synopsis>
       <cmd>@pkgsysconfdir@/avahi-dnsconfd.action</cmd>
-	</synopsis>
+    </synopsis>
 
     <description>
       <p><file>avahi-dnsconfd.action</file> is the action script that
@@ -33,9 +33,9 @@
        removed by avahi-dnsconfd. The default script as shipped
       with avahi patches <file>/etc/resolv.conf</file> to reflect the
       changed unicast DNS server configuration.</p>
-	</description>
+    </description>
 
-	<section name="Parameters">
+    <section name="Parameters">
 
       <option>
         <p><opt>argv[1]</opt> Contains the character "+" if the DNS server is new, "-" when it shall be removed from the DNS server list.</p>
@@ -53,9 +53,9 @@
         <p><opt>argv[4]</opt> Numerical protocol number this DNS server was found on. (usually 2 for IPv4 and 10 for IPv6) </p>
       </option>
 
-	</section>
+    </section>
 
-	<section name="Environment">
+    <section name="Environment">
       <option>
         <p><opt>AVAHI_INTERFACE</opt> Contains the textual interface name the corresponds with argv[3]. (e.g. "eth0")</p>
       </option>
@@ -71,20 +71,20 @@
 
     </section>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-dnsconfd" section="8"/>, <manref name="avahi-daemon" section="8"/>
-	  </p>
-	</section>
+      </p>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man" section="1"
-		  href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man" section="1"
+          href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/avahi-publish.1.xml.in
+++ b/man/avahi-publish.1.xml.in
@@ -23,18 +23,18 @@
 
   <manpage name="avahi-publish-service" section="1" desc="Register an mDNS/DNS-SD service or host name or address mapping using the Avahi daemon">
 
-	<synopsis>
+  <synopsis>
       <cmd>avahi-publish -s [<arg>options</arg>] <arg>name</arg> <arg>service-type</arg> <arg>port</arg> [<arg>TXT data</arg> ...]</cmd>
       <cmd>avahi-publish-service [<arg>options</arg>] <arg>name</arg> <arg>service-type</arg> <arg>port</arg> [<arg>TXT data</arg> ...]</cmd>
       <cmd>avahi-publish -a [<arg>options</arg>] <arg>host name</arg> <arg>address</arg></cmd>
       <cmd>avahi-publish-address [<arg>options</arg>] <arg>host name</arg> <arg>address</arg></cmd>
-	</synopsis>
+  </synopsis>
 
     <description>
       <p>Register an mDNS/DNS-SD service or host name/address mapping using the Avahi daemon.</p>
-	</description>
+  </description>
 
-	<options>
+  <options>
 
       <p>When calling in service registration mode, specify a DNS-SD
       service name (e.g. "Lennart's Files"), a service type
@@ -44,12 +44,12 @@
       mode specify a fully qualified host name and an address (IPv4 or
       IPv6).</p>
 
-	  <option>
+    <option>
         <p><opt>-s | --service</opt></p>
         <optdesc><p>Register a service. avahi-publish-service is equivalent to avahi-publish -s.</p></optdesc>
       </option>
 
-	  <option>
+    <option>
         <p><opt>-a | --address</opt></p>
         <optdesc><p>Register an address/host name mapping. avahi-publish-address is equivalent to avahi-publish -a.</p></optdesc>
       </option>
@@ -60,19 +60,19 @@
       </option>
 
       <option>
-		<p><opt>-H | --host=</opt> <arg>HOSTNAME</arg></p>
-		<optdesc><p>Specify a host name for this service, in case it
-		doesn't reside on the local host. This host name needs to be
-		fully qualified and resolvable using mDNS or unicast
-		DNS.</p></optdesc>
-	  </option>
+    <p><opt>-H | --host=</opt> <arg>HOSTNAME</arg></p>
+    <optdesc><p>Specify a host name for this service, in case it
+    doesn't reside on the local host. This host name needs to be
+    fully qualified and resolvable using mDNS or unicast
+    DNS.</p></optdesc>
+    </option>
 
-	  <option>
-		<p><opt>-d | --domain=</opt> <arg>DOMAIN</arg></p>
+    <option>
+    <p><opt>-d | --domain=</opt> <arg>DOMAIN</arg></p>
         <optdesc><p>Publish the service in the specified domain. If
         omitted the Avahi daemon will publish it in its default domain
         (usually .local).</p></optdesc>
-	  </option>
+    </option>
 
       <option>
         <p><opt>--subtype=</opt> <arg>SUBTYPE</arg></p>
@@ -89,39 +89,39 @@
         <optdesc><p>Do not publish reverse entry with address.</p></optdesc>
       </option>
 
-	  <option>
-		<p><opt>-f | --no-fail</opt></p>
-		<optdesc><p>Don't fail if the daemon is not found running. Instead, wait until it appears. If it disconnects, try to reconnect.</p></optdesc>
-	  </option>
+    <option>
+    <p><opt>-f | --no-fail</opt></p>
+    <optdesc><p>Don't fail if the daemon is not found running. Instead, wait until it appears. If it disconnects, try to reconnect.</p></optdesc>
+    </option>
 
-	  <option>
-		<p><opt>-h | --help</opt></p>
-		<optdesc><p>Show help</p></optdesc>
-	  </option>
+    <option>
+    <p><opt>-h | --help</opt></p>
+    <optdesc><p>Show help</p></optdesc>
+    </option>
 
-	  <option>
-		<p><opt>-V | --version</opt></p>
-		<optdesc><p>Show version information.</p></optdesc>
-	  </option>
+    <option>
+    <p><opt>-V | --version</opt></p>
+    <optdesc><p>Show version information.</p></optdesc>
+    </option>
 
-	</options>
+  </options>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+  <section name="Authors">
+    <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+    available from <url href="@PACKAGE_URL@"/></p>
+  </section>
 
-	<section name="See also">
-	  <p>
+  <section name="See also">
+    <p>
         <manref name="avahi-resolve" section="1"/>, <manref
         name="avahi-browse" section="1"/>, <manref
         name="avahi-daemon" section="8"/>
-	  </p>
-	</section>
+    </p>
+  </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man" section="1"
-		  href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
-	</section>
+  <section name="Comments">
+    <p>This man page was written using <manref name="xml2man" section="1"
+      href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
+  </section>
 
   </manpage>

--- a/man/avahi-resolve.1.xml.in
+++ b/man/avahi-resolve.1.xml.in
@@ -23,18 +23,18 @@
 
   <manpage name="avahi-resolve" section="1" desc="Resolve one or more mDNS/DNS host name(s) to IP address(es) (and vice versa) using the Avahi daemon">
 
-	<synopsis>
+    <synopsis>
       <cmd>avahi-resolve --name <arg>host-name ...</arg></cmd>
       <cmd>avahi-resolve-host-name <arg>host-name ...</arg></cmd>
       <cmd>avahi-resolve --address <arg>address ...</arg></cmd>
       <cmd>avahi-resolve-address <arg>address ...</arg></cmd>
-	</synopsis>
+    </synopsis>
 
     <description>
       <p>Resolve one or more mDNS/DNS host name(s) to IP address(es) (and vice versa) using the Avahi daemon.</p>
-	</description>
+    </description>
 
-	<options>
+    <options>
 
       <p>When passing -n, specify one or more fully qualified mDNS/DNS host name(s)
       (e.g. "foo.local") to resolve into IP addresses on the command line.</p>
@@ -48,15 +48,15 @@
 
       <p>avahi-resolve-address is equivalent to avahi-resolve --address.</p>
 
-	  <option>
-		<p><opt>-n | --name</opt></p>
-		<optdesc><p>Translate one or more fully qualified host names into addresses.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-n | --name</opt></p>
+        <optdesc><p>Translate one or more fully qualified host names into addresses.</p></optdesc>
+      </option>
 
-	  <option>
-		<p><opt>-a | --address</opt></p>
-		<optdesc><p>Translate one or more addresses into fully qualified host names.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-a | --address</opt></p>
+        <optdesc><p>Translate one or more addresses into fully qualified host names.</p></optdesc>
+      </option>
 
       <option>
         <p><opt>-v | --verbose</opt></p>
@@ -73,36 +73,36 @@
         <optdesc><p>When resolving a host name, look for IPv4 addresses exclusively.</p></optdesc>
       </option>
 
-	  <option>
-		<p><opt>-h | --help</opt></p>
-		<optdesc><p>Show help.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-h | --help</opt></p>
+        <optdesc><p>Show help.</p></optdesc>
+      </option>
 
 
-	  <option>
-		<p><opt>-V | --version</opt></p>
-		<optdesc><p>Show version information.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-V | --version</opt></p>
+        <optdesc><p>Show version information.</p></optdesc>
+      </option>
 
 
-	</options>
+    </options>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-publish-address" section="1"/>,
         <manref
         name="avahi-daemon" section="8"/>
-	  </p>
-	</section>
+      </p>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man" section="1"
-		  href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man" section="1"
+          href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/avahi-set-host-name.1.xml.in
+++ b/man/avahi-set-host-name.1.xml.in
@@ -23,51 +23,51 @@
 
   <manpage name="avahi-set-host-name" section="1" desc="Change mDNS host name">
 
-	<synopsis>
+    <synopsis>
       <cmd>avahi-set-host-name <arg>host-name</arg></cmd>
-	</synopsis>
+    </synopsis>
 
     <description>
       <p>Set the mDNS host name of a currently running Avahi
       daemon. The effect of this operation is not persistent across
       daemon restarts. This operation is usually privileged.</p>
-	</description>
+    </description>
 
-	<options>
+    <options>
 
       <option>
         <p><opt>-v | --verbose</opt></p>
         <optdesc><p>Enable verbose mode.</p></optdesc>
       </option>
 
-	  <option>
-		<p><opt>-h | --help</opt></p>
-		<optdesc><p>Show help.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-h | --help</opt></p>
+        <optdesc><p>Show help.</p></optdesc>
+      </option>
 
 
-	  <option>
-		<p><opt>-V | --version</opt></p>
-		<optdesc><p>Show version information.</p></optdesc>
-	  </option>
+      <option>
+        <p><opt>-V | --version</opt></p>
+        <optdesc><p>Show version information.</p></optdesc>
+      </option>
 
 
-	</options>
+    </options>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-daemon" section="8"/>
-	  </p>
-	</section>
+      </p>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man" section="1"
-		  href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man" section="1"
+          href="http://masqmail.cx/xml2man/"/> by Oliver Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/avahi.hosts.5.xml.in
+++ b/man/avahi.hosts.5.xml.in
@@ -23,9 +23,9 @@
 
   <manpage name="avahi.hosts" section="5" desc="avahi-daemon static host name file">
 
-	<synopsis>
+    <synopsis>
       <cmd>@pkgsysconfdir@/hosts</cmd>
-	</synopsis>
+    </synopsis>
 
     <description>
       <p><file>@pkgsysconfdir@/hosts</file> is a file which may be used
@@ -40,21 +40,21 @@
       i.e. with appended .local suffix.</p>
     </description>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-daemon" section="8"/>, <manref name="avahi.service" section="5"/>
-	  </p>
-	</section>
+      </p>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man"
-	  section="1" href="http://masqmail.cx/xml2man/"/> by Oliver
-	  Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man"
+      section="1" href="http://masqmail.cx/xml2man/"/> by Oliver
+      Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/avahi.service.5.xml.in
+++ b/man/avahi.service.5.xml.in
@@ -23,9 +23,9 @@
 
   <manpage name="avahi.service" section="5" desc="avahi-daemon static service file">
 
-	<synopsis>
+    <synopsis>
       <cmd>@servicedir@/*.service</cmd>
-	</synopsis>
+    </synopsis>
 
     <description> <p><file>@servicedir@/*.service</file> are XML
       fragments containing static DNS-SD service data. Every service
@@ -34,7 +34,7 @@
       services which implement multiple protocols. (i.e. a printer
       implementing _ipp._tcp and _printer._tcp)</p> </description>
 
-	<section name="XML Tags">
+    <section name="XML Tags">
 
       <option>
         <p><opt>&lt;service-group&gt;</opt> The document tag of avahi
@@ -121,23 +121,23 @@
       </option>
 
 
-	</section>
+    </section>
 
-	<section name="Authors">
-	  <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
-	  available from <url href="@PACKAGE_URL@"/></p>
-	</section>
+    <section name="Authors">
+      <p>The Avahi Developers &lt;@PACKAGE_BUGREPORT@&gt;; Avahi is
+      available from <url href="@PACKAGE_URL@"/></p>
+    </section>
 
-	<section name="See also">
-	  <p>
+    <section name="See also">
+      <p>
         <manref name="avahi-daemon" section="8"/>, <manref name="avahi.hosts" section="5"/>
-	  </p>
-	</section>
+      </p>
+    </section>
 
-	<section name="Comments">
-	  <p>This man page was written using <manref name="xml2man"
-	  section="1" href="http://masqmail.cx/xml2man/"/> by Oliver
-	  Kurth.</p>
-	</section>
+    <section name="Comments">
+      <p>This man page was written using <manref name="xml2man"
+      section="1" href="http://masqmail.cx/xml2man/"/> by Oliver
+      Kurth.</p>
+    </section>
 
   </manpage>

--- a/man/bssh.1.xml.in
+++ b/man/bssh.1.xml.in
@@ -41,30 +41,30 @@
     <options>
 
       <option>
-	<p><opt>-s | --ssh</opt></p>
-	<optdesc><p>Browse for SSH servers (and only SSH servers)  regardless under which name the binary is called.</p></optdesc>
+    <p><opt>-s | --ssh</opt></p>
+    <optdesc><p>Browse for SSH servers (and only SSH servers)  regardless under which name the binary is called.</p></optdesc>
       </option>
 
       <option>
-	<p><opt>-v | --vnc</opt></p>
-	<optdesc><p>Browse for VNC servers (and only VNC servers) regardless under which name the binary is called.</p></optdesc>
+    <p><opt>-v | --vnc</opt></p>
+    <optdesc><p>Browse for VNC servers (and only VNC servers) regardless under which name the binary is called.</p></optdesc>
       </option>
 
       <option>
-	<p><opt>-S | --shell</opt></p>
-	<optdesc><p>Browse for both VNC and SSH servers regardless under which name the binary is called.</p></optdesc>
+    <p><opt>-S | --shell</opt></p>
+    <optdesc><p>Browse for both VNC and SSH servers regardless under which name the binary is called.</p></optdesc>
       </option>
 
       <option>
-	<p><opt>-d | --domain=</opt> <arg>DOMAIN</arg></p>
+    <p><opt>-d | --domain=</opt> <arg>DOMAIN</arg></p>
         <optdesc><p>Browse in the specified domain. If omitted
             bssh/bvnc/bshell will browse in the default browsing domain
             (usually .local)</p></optdesc>
       </option>
 
       <option>
-	<p><opt>-h | --help</opt></p>
-	<optdesc><p>Show help.</p></optdesc>
+    <p><opt>-h | --help</opt></p>
+    <optdesc><p>Show help.</p></optdesc>
       </option>
 
     </options>


### PR DESCRIPTION
There is a mixture of spaces of tabs in the manual pages, convert to spaces only.