### PR TITLE
ci: bring back clang-analyzer on OpenScanHub

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -8,7 +8,7 @@ upstream_package_name: avahi
 downstream_package_name: avahi
 upstream_tag_template: "v{version}"
 srpm_build_deps: []
-csmock_args: --cppcheck-add-flag=--enable=style
+csmock_args: --cppcheck-add-flag=--enable=style -t clang
 
 actions:
   post-upstream-clone:


### PR DESCRIPTION
It was turned off on OpenScanHub because it produces a lot of unix.Malloc false positives in projects using the cleanup attribute but since it isn't applicable to the avahi codebase (unfortunately) it can safely be brought back. Among other things it should help to review PRs addressing/introducing clang-analyzer findings and keep track of them in general.