### PR TITLE
Fix 32-bit overflow for avoiding year 2038 problem

### DIFF
--- a/avahi-common/timeval.c
+++ b/avahi-common/timeval.c
@@ -83,15 +83,15 @@ AvahiUsec avahi_age(const struct timeval *a) {
     return avahi_timeval_diff(&now, a);
 }
 
-struct timeval *avahi_elapse_time(struct timeval *tv, unsigned msec, unsigned jitter) {
+struct timeval *avahi_elapse_time(struct timeval *tv, AvahiUsec usec, AvahiUsec j) {
     assert(tv);
 
     gettimeofday(tv, NULL);
 
-    if (msec)
-        avahi_timeval_add(tv, (AvahiUsec) msec*1000);
+    if (usec)
+        avahi_timeval_add(tv, usec);
 
-    if (jitter) {
+    if (j) {
         static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
         static int last_rand;
         static time_t timestamp = 0;
@@ -115,7 +115,7 @@ struct timeval *avahi_elapse_time(struct timeval *tv, unsigned msec, unsigned ji
          * time events elapse in bursts which has the advantage that
          * packet data can be aggregated better */
 
-        avahi_timeval_add(tv, (AvahiUsec) (jitter*1000.0*r/(RAND_MAX+1.0)));
+        avahi_timeval_add(tv, (AvahiUsec) (j * 1.0 * r / (RAND_MAX + 1.0)));
     }
 
     return tv;

--- a/avahi-common/timeval.h
+++ b/avahi-common/timeval.h
@@ -44,10 +44,10 @@ struct timeval* avahi_timeval_add(struct timeval *a, AvahiUsec usec);
 /** Return the difference between the current time and *a. Positive if *a was earlier */
 AvahiUsec avahi_age(const struct timeval *a);
 
-/** Fill *tv with the current time plus "ms" milliseconds plus an
- * extra jitter of "j" milliseconds. Pass 0 for j if you don't want
+/** Fill *tv with the current time plus "usec" microseconds plus an
+ * extra jitter of "j" microseconds. Pass 0 for j if you don't want
  * the jitter */
-struct timeval *avahi_elapse_time(struct timeval *tv, unsigned ms, unsigned j);
+struct timeval *avahi_elapse_time(struct timeval *tv, AvahiUsec usec, AvahiUsec j);
 
 AVAHI_C_DECL_END
 

--- a/avahi-core/announce.c
+++ b/avahi-core/announce.c
@@ -107,7 +107,7 @@ void avahi_s_entry_group_check_probed(AvahiSEntryGroup *g, int immediately) {
             } else {
                 struct timeval tv;
                 a->n_iteration = 0;
-                avahi_elapse_time(&tv, 0, AVAHI_ANNOUNCEMENT_JITTER_MSEC);
+                avahi_elapse_time(&tv, 0, AVAHI_ANNOUNCEMENT_JITTER_MSEC * 1000);
                 set_timeout(a, &tv);
             }
         }
@@ -147,7 +147,7 @@ static void next_state(AvahiAnnouncer *a) {
 
             avahi_interface_post_probe(a->interface, a->entry->record, 0);
 
-            avahi_elapse_time(&tv, AVAHI_PROBE_INTERVAL_MSEC, 0);
+            avahi_elapse_time(&tv, AVAHI_PROBE_INTERVAL_MSEC * 1000, 0);
             set_timeout(a, &tv);
 
             a->n_iteration++;
@@ -171,7 +171,7 @@ static void next_state(AvahiAnnouncer *a) {
             set_timeout(a, NULL);
         } else {
             struct timeval tv;
-            avahi_elapse_time(&tv, a->sec_delay*1000, AVAHI_ANNOUNCEMENT_JITTER_MSEC);
+            avahi_elapse_time(&tv, a->sec_delay*1000*1000, AVAHI_ANNOUNCEMENT_JITTER_MSEC * 1000);
 
             if (a->n_iteration < 10)
                 a->sec_delay *= 2;
@@ -227,9 +227,9 @@ static void go_to_initial_state(AvahiAnnouncer *a) {
         e->group->n_probing++;
 
     if (a->state == AVAHI_PROBING)
-        set_timeout(a, avahi_elapse_time(&tv, 0, AVAHI_PROBE_JITTER_MSEC));
+        set_timeout(a, avahi_elapse_time(&tv, 0, AVAHI_PROBE_JITTER_MSEC * 1000));
     else if (a->state == AVAHI_ANNOUNCING)
-        set_timeout(a, avahi_elapse_time(&tv, 0, AVAHI_ANNOUNCEMENT_JITTER_MSEC));
+        set_timeout(a, avahi_elapse_time(&tv, 0, AVAHI_ANNOUNCEMENT_JITTER_MSEC * 1000));
     else
         set_timeout(a, NULL);
 }
@@ -465,9 +465,9 @@ static void reannounce(AvahiAnnouncer *a) {
     a->sec_delay = 1;
 
     if (a->state == AVAHI_PROBING)
-        set_timeout(a, avahi_elapse_time(&tv, 0, AVAHI_PROBE_JITTER_MSEC));
+        set_timeout(a, avahi_elapse_time(&tv, 0, AVAHI_PROBE_JITTER_MSEC * 1000));
     else if (a->state == AVAHI_ANNOUNCING)
-        set_timeout(a, avahi_elapse_time(&tv, 0, AVAHI_ANNOUNCEMENT_JITTER_MSEC));
+        set_timeout(a, avahi_elapse_time(&tv, 0, AVAHI_ANNOUNCEMENT_JITTER_MSEC * 1000));
     else
         set_timeout(a, NULL);
 }

--- a/avahi-core/probe-sched.c
+++ b/avahi-core/probe-sched.c
@@ -98,13 +98,13 @@ static void job_free(AvahiProbeScheduler *s, AvahiProbeJob *pj) {
 
 static void elapse_callback(AvahiTimeEvent *e, void* data);
 
-static void job_set_elapse_time(AvahiProbeScheduler *s, AvahiProbeJob *pj, unsigned msec, unsigned jitter) {
+static void job_set_elapse_time(AvahiProbeScheduler *s, AvahiProbeJob *pj, AvahiUsec usec, AvahiUsec jitter) {
     struct timeval tv;
 
     assert(s);
     assert(pj);
 
-    avahi_elapse_time(&tv, msec, jitter);
+    avahi_elapse_time(&tv, usec, jitter);
 
     if (pj->time_event)
         avahi_time_event_update(pj->time_event, &tv);
@@ -123,7 +123,7 @@ static void job_mark_done(AvahiProbeScheduler *s, AvahiProbeJob *pj) {
 
     pj->done = 1;
 
-    job_set_elapse_time(s, pj, AVAHI_PROBE_HISTORY_MSEC, 0);
+    job_set_elapse_time(s, pj, AVAHI_PROBE_HISTORY_MSEC * 1000, 0);
     gettimeofday(&pj->delivery, NULL);
 }
 
@@ -352,7 +352,7 @@ static AvahiProbeJob* find_history_job(AvahiProbeScheduler *s, AvahiRecord *reco
         if (avahi_record_equal_no_ttl(pj->record, record)) {
             /* Check whether this entry is outdated */
 
-            if (avahi_age(&pj->delivery) > AVAHI_PROBE_HISTORY_MSEC*1000) {
+            if (avahi_age(&pj->delivery) > AVAHI_PROBE_HISTORY_MSEC * 1000) {
                 /* it is outdated, so let's remove it */
                 job_free(s, pj);
                 return NULL;
@@ -376,7 +376,7 @@ int avahi_probe_scheduler_post(AvahiProbeScheduler *s, AvahiRecord *record, int 
     if ((pj = find_history_job(s, record)))
         return 0;
 
-    avahi_elapse_time(&tv, immediately ? 0 : AVAHI_PROBE_DEFER_MSEC, 0);
+    avahi_elapse_time(&tv, immediately ? 0 : AVAHI_PROBE_DEFER_MSEC * 1000, 0);
 
     if ((pj = find_scheduled_job(s, record))) {
 

--- a/avahi-core/server.c
+++ b/avahi-core/server.c
@@ -853,7 +853,7 @@ static void reflect_legacy_unicast_query_packet(AvahiServer *s, AvahiDnsPacket *
     slot->port = port;
     slot->interface = i->hardware->index;
 
-    avahi_elapse_time(&slot->elapse_time, 2000, 0);
+    avahi_elapse_time(&slot->elapse_time, 2000 * 1000, 0);
     slot->time_event = avahi_time_event_new(s->time_event_queue, &slot->elapse_time, legacy_unicast_reflect_slot_timeout, slot);
 
     /* Patch the packet with our new locally generatet id */


### PR DESCRIPTION

`unsigned int` 32-bit dangeours use for `msec` and `jitter`, since it is multiplied by 1000, judging by code before PR changes.

References:
- https://en.wikipedia.org/wiki/Year_2038_problem
- https://www.gnu.org/software/gnulib/manual/html_node/Avoiding-the-year-2038-problem.html
