### PR TITLE
avahi-core: fix duplicate function definitions in browse.c

### DIFF
--- a/avahi-core/browse.c
+++ b/avahi-core/browse.c
@@ -400,40 +400,6 @@ static int lookup_go(AvahiSRBLookup *l) {
     return n;
 }
 
-static int lookup_exists_in_path(AvahiSRBLookup* lookup, AvahiSRBLookup* from, AvahiSRBLookup* to) {
-    AvahiRList* rl;
-    if (from == to)
-        return 0;
-    for (rl = from->cname_lookups; rl; rl = rl->rlist_next) {
-        int r = lookup_exists_in_path(lookup, rl->data, to);
-        if (r == 1) {
-            /* loop detected, propagate result */
-            return r;
-        } else if (r == 0) {
-            /* is loop detected? */
-            return lookup == from;
-        } else {
-	        /* `to` not found, continue */
-            continue;
-        }
-    }
-    /* no path found */
-    return -1;
-}
-
-static int cname_would_create_loop(AvahiSRBLookup* l, AvahiSRBLookup* n) {
-    int ret;
-    if (l == n)
-        /* Loop to self */
-        return 1;
-
-    ret = lookup_exists_in_path(n, l->record_browser->root_lookup, l);
-
-    /* Path to n always exists */
-    assert(ret != -1);
-    return ret;
-}
-
 static void lookup_handle_cname(AvahiSRBLookup *l, AvahiIfIndex interface, AvahiProtocol protocol, AvahiLookupFlags flags, AvahiRecord *r) {
     AvahiKey *k;
     AvahiSRBLookup *n;


### PR DESCRIPTION
The browse.c file in avahi 0.9-rc3 contains duplicate definitions of two static functions:
- lookup_exists_in_path
- cname_would_create_loop

This causes compilation to fail with redefinition errors:
```
  browse.c:437:12: error: redefinition of 'lookup_exists_in_path'
  browse.c:458:12: error: redefinition of 'cname_would_create_loop'
```
The duplicate definitions are identical to the originals, so this patch removes the second occurrence of both functions while keeping the first definitions intact.