### PR TITLE
ci: run more tests under Valgrind

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -333,7 +333,11 @@ case "$1" in
             fi
         fi
 
-        $MAKE check VERBOSE=1
+        if [[ "$VALGRIND" == true ]]; then
+            $MAKE check VERBOSE=1 LOG_COMPILER="valgrind --leak-check=full --track-origins=yes --track-fds=yes --error-exitcode=1"
+        else
+            $MAKE check VERBOSE=1
+        fi
 
         # It's just a kludge using the existing valgrind target
         # to run at least something under Valgrind on FreeBSD. It was


### PR DESCRIPTION
by wrapping the tests launched by `make check` with Valgrind.

It's useful by itself but it's also prompted by PRs increasing the coverage of the testsuite. With that it should be on par with the smoke tests in terms of exercising it all under ASan/UBSan and Valgrind.