### PR TITLE
Fix crash in `avahi-publish -a` by erroring out on name collisions

### DIFF
--- a/avahi-utils/avahi-publish.c
+++ b/avahi-utils/avahi-publish.c
@@ -88,7 +88,9 @@ static void entry_group_callback(AvahiEntryGroup *g, AvahiEntryGroupState state,
                 n = avahi_alternative_service_name(config->name);
             else {
                 assert(config->command == COMMAND_PUBLISH_ADDRESS);
-                n = avahi_alternative_host_name(config->name);
+                fprintf(stderr, _("Name collision detected, '%s' was already published by another network member.\n"), config->name);
+                avahi_simple_poll_quit(simple_poll);
+                break;
             }
 
             fprintf(stderr, _("Name collision, picking new name '%s'.\n"), n);


### PR DESCRIPTION
Fixes #478 by erroring out when a name collision occurs.

An alternative fix would be to enforce single-label names after parsing the arguments by checking `config->name` (then adding `.local` in `register_stuff()`). Multi-label names aren't forbidden by the RFC, so it wouldn't make much sense to disallow them.

@evverx Which approach do you prefer?