### PR TITLE
ci: use $OS instead of ubuntu

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -107,7 +107,7 @@ trim_sandbox() {
 
 case "$1" in
     install-build-deps)
-        sed -i 's/^\(Types: deb\)$/\1 deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+        sed -i 's/^\(Types: deb\)$/\1 deb-src/' "/etc/apt/sources.list.d/$OS.sources"
         apt-get update -y
         apt-get build-dep -y avahi
         apt-get install -y libevent-dev qtbase5-dev libsystemd-dev systemd-dev


### PR DESCRIPTION
to make it work on Debian as well.

It all works perfectly fine on Debian with modernized sources as well so there is no need to limit it to Ubuntu only.