### PR TITLE
compat-libdns_sd: remove thread_running flag and simplify thread teardown

### DIFF
--- a/avahi-compat-libdns_sd/compat.c
+++ b/avahi-compat-libdns_sd/compat.c
@@ -308,8 +308,6 @@ static void * thread_func(void *data) {
     sigfillset(&mask);
     pthread_sigmask(SIG_BLOCK, &mask, NULL);
 
-    sdref->thread = pthread_self();
-
     for (;;) {
         char command;
 


### PR DESCRIPTION
this is a follow on from discussion at #783 - it doesn't change the discussion - or the state/question of the `compat-libdns_sd` library (maintained or abandoned). This is only meant to save a little typing if anyone wants it...

The `thread_running` flag was originally introduced ~20 years ago as a defensive approximation of the worker thread's lifecycle. At the time, there was concern about safely joining threads, and the flag was used to conditionally decide whether to signal and join the thread.

ThreadSanitizer now reports a data race on this flag during teardown, showing it is both unsynchronized and unnecessary. Modern POSIX semantics guarantee that:
 - `pthread_create()` establishes a valid, joinable thread, and
 - `pthread_join()` safely waits for thread termination.

The `thread_running` flag is therefore redundant. This commit removes it entirely and updates `sdref_free()` to unconditionally signal and `join()` the worker thread, eliminating the race and simplifying the thread lifecycle logic.

No functional behavior is changed; the change only fixes the race and removes dead state.

TSan report:
```
rgetz@brain:~/github/avahi/build$ ./avahi-compat-libdns_sd/null-test *** WARNING *** The program 'null-test' uses the Apple Bonjour compatibility layer of Avahi. *** WARNING *** Please fix your application to use the native API of Avahi! *** WARNING *** For more information see <http://0pointer.de/blog/projects/avahi-compat.html> ==================
WARNING: ThreadSanitizer: data race (pid=127259)
  Write of size 4 at 0x724000000020 by main thread:
    #0 sdref_new /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:410:27 (null-test+0xe85d8) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)
    #1 DNSServiceRegister /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:1137:19 (null-test+0xe97b5) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)
    #2 main /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/null-test.c:48:5 (null-test+0xeafac) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)

  Previous write of size 4 at 0x724000000020 by thread T1:
    #0 thread_func /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:314:27 (null-test+0xeaa98) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)

  Location is heap block of size 248 at 0x724000000000 allocated by main thread:
    #0 calloc <null> (null-test+0x6275f) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)
    #1 xcalloc /home/rgetz/github/avahi/build/avahi-common/../../avahi-common/malloc.c:95:15 (libavahi-common.so.3+0x37ed) (BuildId: c9ddf54bb63e77b7f9000914b560c57bd72f0296)
    #2 avahi_malloc0 /home/rgetz/github/avahi/build/avahi-common/../../avahi-common/malloc.c:120:16 (libavahi-common.so.3+0x37ed)
    #3 avahi_new0_internal /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-common/malloc.h:59:12 (null-test+0xe8443) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)
    #4 sdref_new /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:370:19 (null-test+0xe8443)
    #5 DNSServiceRegister /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:1137:19 (null-test+0xe97b5) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)
    #6 main /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/null-test.c:48:5 (null-test+0xeafac) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)

  Thread T1 (tid=127274, running) created by main thread at:
    #0 pthread_create <null> (null-test+0x64095) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)
    #1 sdref_new /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:407:9 (null-test+0xe85a8) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)
    #2 DNSServiceRegister /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:1137:19 (null-test+0xe97b5) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)
    #3 main /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/null-test.c:48:5 (null-test+0xeafac) (BuildId: 85805d993fe4ed02ea1a2b702a0af3db9959b09e)
```
and once you remove the write to `thread_running` = 1, from the main thread, this shows up:
```
WARNING: ThreadSanitizer: data race (pid=148954)
  Read of size 4 at 0x724000000320 by main thread:
    #0 sdref_free /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:423:16 (null-test+0xe7b7b) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)
    #1 sdref_unref /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:467:9 (null-test+0xe7b7b)
    #2 DNSServiceRefDeallocate /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:526:9 (null-test+0xe7e23) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)
    #3 main /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/null-test.c:68:5 (null-test+0xeb204) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)

  Previous write of size 4 at 0x724000000320 by thread T4:
    #0 thread_func /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:314:27 (null-test+0xeaa88) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)

  As if synchronized via sleep:
    #0 sleep <null> (null-test+0x60ecc) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)
    #1 main /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/null-test.c:63:5 (null-test+0xeb1bd) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)

  Location is heap block of size 248 at 0x724000000300 allocated by main thread:
    #0 calloc <null> (null-test+0x6275f) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)
    #1 xcalloc /home/rgetz/github/avahi/build/avahi-common/../../avahi-common/malloc.c:95:15 (libavahi-common.so.3+0x37ed) (BuildId: c9ddf54bb63e77b7f9000914b560c57bd72f0296)
    #2 avahi_malloc0 /home/rgetz/github/avahi/build/avahi-common/../../avahi-common/malloc.c:120:16 (libavahi-common.so.3+0x37ed)
    #3 avahi_new0_internal /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-common/malloc.h:59:12 (null-test+0xe8443) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)
    #4 sdref_new /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:370:19 (null-test+0xe8443)
    #5 DNSServiceBrowse /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:639:19 (null-test+0xe7f43) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)
    #6 main /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/null-test.c:61:5 (null-test+0xeb1b3) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)

  Thread T4 (tid=148972, running) created by main thread at:
    #0 pthread_create <null> (null-test+0x64095) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)
    #1 sdref_new /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:407:9 (null-test+0xe85a5) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)
    #2 DNSServiceBrowse /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:639:19 (null-test+0xe7f43) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)
    #3 main /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/null-test.c:61:5 (null-test+0xeb1b3) (BuildId: 09e79e7429e644e9a573e78ef2841693cee51225)

SUMMARY: ThreadSanitizer: data race /home/rgetz/github/avahi/build/avahi-compat-libdns_sd/../../avahi-compat-libdns_sd/compat.c:423:16 in sdref_free
```
Which is the read of `thread_running` in `sdref_free()`.

so, since you don't need it - just remove it all.