### PR TITLE
ci: no longer sync files from VMs to runners

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -94,11 +94,6 @@ install_radamsa() {
     CFLAGS="" $MAKE -j"$(nproc)"
     $MAKE install
     popd
-    # At least radamsa.c is generated with the "-rw-------." permissions so
-    # cross-platform-actions/action trips on that with:
-    #  /usr/bin/rsync -auz runner@cross_platform_actions_host:/home/runner/work/ /home/runner/work
-    #   rsync: [sender] send_files failed to open "/home/runner/work/avahi/avahi/radamsa/radamsa.c": Permission denied (13)
-    chmod -R a+r radamsa
 }
 
 trim_sandbox() {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
           operating_system: ${{ matrix.os }}
           version: ${{ matrix.version }}
           architecture: 'x86_64'
+          sync_files: 'runner-to-vm'
           environment_variables: ASAN_UBSAN CC DISTCHECK VALGRIND
           run: |
             sudo -E .github/workflows/build.sh install-build-deps-${{ matrix.os }}

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -154,7 +154,6 @@ install_nss_mdns() {
     $MAKE install
     popd
 
-    chmod -R a+r "$NSS_MDNS_BUILD_DIR"
     CFLAGS="$_cflags" CXXFLAGS="$_cxxflags" ASAN_OPTIONS="$_asan_options" LD_PRELOAD="$_ld_preload"
 
     run ./avahi-client/check-nss-test


### PR DESCRIPTION
and drop the kludges related to that.

By default the cross-platform action syncs files from runners to VMs and vice versa:
https://github.com/cross-platform-actions/action/blob/492b0c80085400348c599edace11141a4ee73524/readme.md?plain=1#L138. The avahi CI doesn't use the files copied from VMs though so that part can safely be dropped along with the kludges required to get around issues like
```
/usr/bin/rsync -auz runner@cross_platform_actions_host:/home/runner/work/ /home/runner/work
rsync: [sender] send_files failed to open "/home/runner/work/avahi/avahi/radamsa/radamsa.c": Permission denied (13)
```