### PR TITLE
ci: run all the unit test suites under Valgrind

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -32,6 +32,10 @@ if [[ "$OS" == omnios ]]; then
     PATH="/opt/local/sbin:/opt/local/bin:$PATH"
 fi
 
+if [[ "$VALGRIND" == true ]]; then
+    export LOG_COMPILER="valgrind --leak-check=full --track-origins=yes --track-fds=yes --error-exitcode=1"
+fi
+
 asan_ubsan_reports_detected() {
     local _btraces
 
@@ -328,11 +332,7 @@ case "$1" in
             fi
         fi
 
-        if [[ "$VALGRIND" == true ]]; then
-            $MAKE check VERBOSE=1 LOG_COMPILER="valgrind --leak-check=full --track-origins=yes --track-fds=yes --error-exitcode=1"
-        else
-            $MAKE check VERBOSE=1
-        fi
+        $MAKE check VERBOSE=1
 
         # It's just a kludge using the existing valgrind target
         # to run at least something under Valgrind on FreeBSD. It was

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -138,10 +138,7 @@ install_nss_mdns() {
 
     $MAKE -j"$(nproc)" V=1
 
-    if ! $MAKE check V=1; then
-        cat test-suite.log
-        exit 1
-    fi
+    $MAKE check VERBOSE=1 CK_FORK=no
 
     if [[ "$DISTCHECK" == true ]]; then
         $MAKE distcheck V=1


### PR DESCRIPTION
by exporting LOG_COMPILER and passing it to all the test suites including the nss-mdns test suite.

In "fork" mode the libcheck library produces a lot of file descriptor leak reports like
```
==78260== FILE DESCRIPTORS: 4 open (3 inherited) at exit.
==78260== Open file descriptor 3: /tmp/check_QEUdnu
==78260==    at 0x4A84B9C: open (open64.c:41)
==78260==    by 0x49DF4D7: try_tempname_len (tempname.c:264)
==78260==    by 0x49DF4D7: gen_tempname_len (tempname.c:187)
==78260==    by 0x49DF4D7: __gen_tempname (tempname.c:282)
==78260==    by 0x400F6FB: open_tmp_file (in /root/avahi/nss-mdns/check_util)
==78260==    by 0x400F8C3: receive_test_result (in /root/avahi/nss-mdns/check_util)
==78260==    by 0x40111E1: srunner_run_tagged (in /root/avahi/nss-mdns/check_util)
==78260==    by 0x400D61F: main (check_util.c:1061)
==78260==
...
==78260== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
so this mode is just turned off with CK_FORK=no. The part where the test log is shown is replaced with VERBOSE=1 because it does the same thing and is more consistent overall.

It's a follow-up to b10d81d7b0dbeb41cc5afc716074d97ce55d7d57.