### PR TITLE
ci: make sure DNS servers and cookies are published

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -285,8 +285,11 @@ drill -p5353 @127.0.0.1 test-notifications._qotd._tcp.local ANY
 
 check_rlimit_nofile
 
-h="$(hostname | sed 's/\.local$//').local"
+l=$(hostname | sed 's/\.local$//')
+h="$l.local"
 run drill -p5353 @127.0.0.1 "$h" HINFO
+run drill -p5353 @127.0.0.1 _domain._udp.local ANY
+drill -Q -p5353 @127.0.0.1 "$l._ssh._tcp.local" TXT | grep org.freedesktop.Avahi.cookie
 
 if [[ "$WITH_SYSTEMD" == false ]]; then
     run avahi-dnsconfd --kill


### PR DESCRIPTION
Those settings are flipped in the CI config so it makes sense to make sure they actually take effect. It's prompted by a coverage drop (which was indirectly caught by shellcheck as well). Test failures are easier to spot than coverage drops and shellcheck warnings.

It's a follow-up to dd2fb83e4cb91cb3e3a314692f842932f31ce9b1.