### PR TITLE
retain const qualifier from pointer

### DIFF
--- a/avahi-daemon/static-services.c
+++ b/avahi-daemon/static-services.c
@@ -83,7 +83,8 @@ struct StaticServiceGroup {
 static AVAHI_LLIST_HEAD(StaticServiceGroup, groups) = NULL;
 
 static char *replacestr(const char *pattern, const char *a, const char *b) {
-    char *r = NULL, *e, *n;
+    const char *e;
+    char *r = NULL, *n;
 
     while ((e = strstr(pattern, a))) {
         char *k;
@@ -744,7 +745,7 @@ static void XMLCALL xml_cdata(void *data, const XML_Char *s, int len) {
         case XML_TAG_TXT_RECORD:
             assert(u->service);
             if (u->txt_key == NULL) {
-              char *equals = memchr(s, '=', len);
+              const char *equals = memchr(s, '=', len);
 
               if (equals != NULL) {
                 u->txt_key = append_cdata(u->buf, s, equals - s);


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the in put argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

fixes the follow warnings:
- warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]