### PR TITLE
avahi-discover-standalone: fix assertion crash on malformed PTR records

### DIFF
--- a/avahi-discover-standalone/main.c
+++ b/avahi-discover-standalone/main.c
@@ -146,7 +146,13 @@ static void service_browser_callback(
         s->interface = interface;
         s->protocol = protocol;
         s->service_type = g_hash_table_lookup(service_type_hash_table, service_type);
-        g_assert(s->service_type);
+        if (!s->service_type) {
+            /* Service type not in our tree (like PTR target type mismatch); ignore */
+            g_free(s->service_name);
+            g_free(s->domain_name);
+            g_free(s);
+            return;
+        }
 
         s->service_type->services = g_list_prepend(s->service_type->services, s);
 


### PR DESCRIPTION
If a malicious or misconfigured device broadcasts an unsolicited mDNS PTR record where the target instance belongs to a different service type than the one being queried, the UI client receives a service type it has not previously registered in its tree.

When this happens, `g_hash_table_lookup()` returns NULL. Previously, the code used a hard `g_assert(s->service_type)` on this network-derived data, meaning a single spoofed packet could instantly crash the application.

This commit replaces the unsafe assertion with a defensive check. If the service type is unknown or mismatched, the app now safely frees the allocated memory and ignores the semantically invalid record.

Fixes #679