### PR TITLE
ci: turn off super-linter PR summary comments

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Lint
         uses: super-linter/super-linter/slim@502f4fe48a81a392756e173e39a861f8c8efe056 # v8.3.0
         env:
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
           MULTI_STATUS: false
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_GITHUB_ACTIONS: true


### PR DESCRIPTION
to prevent super-linter>=8.4.0 from failing with
```
2026-03-01 07:02:49 [FATAL]   Failed to get GITHUB_TOKEN.
 Terminating because status reports (MULTI_STATUS: false)
 or pull request summary comments
 (ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: true) were
 explicitly enabled, but GITHUB_TOKEN was not provided.
```

This feature was introduced and turned on by default in https://github.com/super-linter/super-linter/pull/7372 and it was already reported in https://github.com/super-linter/super-linter/issues/7458 that it's too noisy but other than that the logs of the action are enough for the avahi use case (and don't require flipping various write permissions).

It's in preparation for https://github.com/avahi/avahi/pull/876.