### PR TITLE
Correct obsolete FSF address in all license notices

### DIFF
--- a/.github/workflows/coverity.sh
+++ b/.github/workflows/coverity.sh
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 set -eux
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,8 @@
-
                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 2.1, February 1999
 
  Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-	51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -23,8 +22,7 @@ specially designated software packages--typically libraries--of the
 Free Software Foundation and other authors who decide to use it.  You
 can use it too, but we suggest you first think carefully about whether
 this license or the ordinary General Public License is the better
-strategy to use in any particular case, based on the explanations
-below.
+strategy to use in any particular case, based on the explanations below.
 
   When we speak of free software, we are referring to freedom of use,
 not price.  Our General Public Licenses are designed to make sure that
@@ -89,9 +87,9 @@ libraries.  However, the Lesser license provides advantages in certain
 special circumstances.
 
   For example, on rare occasions, there may be a special need to
-encourage the widest possible use of a certain library, so that it
-becomes a de-facto standard.  To achieve this, non-free programs must
-be allowed to use the library.  A more frequent case is that a free
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
 library does the same job as widely used non-free libraries.  In this
 case, there is little to gain by limiting the free library to free
 software only, so we use the Lesser General Public License.
@@ -138,8 +136,8 @@ included without limitation in the term "modification".)
   "Source code" for a work means the preferred form of the work for
 making modifications to it.  For a library, complete source code means
 all the source code for all modules it contains, plus any associated
-interface definition files, plus the scripts used to control
-compilation and installation of the library.
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
 
   Activities other than copying, distribution and modification are not
 covered by this License; they are outside its scope.  The act of
@@ -305,10 +303,10 @@ of these things:
     the user installs one, as long as the modified version is
     interface-compatible with the version that the work was made with.
 
-    c) Accompany the work with a written offer, valid for at least
-    three years, to give the same user the materials specified in
-    Subsection 6a, above, for a charge no more than the cost of
-    performing this distribution.
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
 
     d) If distribution of the work is made by offering access to copy
     from a designated place, offer equivalent access to copy the above
@@ -386,10 +384,9 @@ all those who receive copies directly or indirectly through you, then
 the only way you could satisfy both it and this License would be to
 refrain entirely from distribution of the Library.
 
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply, and the section as a whole is intended to apply in other
-circumstances.
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
 
 It is not the purpose of this section to induce you to infringe any
 patents or other property right claims or to contest validity of any
@@ -407,11 +404,11 @@ be a consequence of the rest of this License.
 
   12. If the distribution and/or use of the Library is restricted in
 certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Library under this License
-may add an explicit geographical distribution limitation excluding those
-countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
-the limitation as if written in the body of this License.
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
 
   13. The Free Software Foundation may publish revised and/or new
 versions of the Lesser General Public License from time to time.
@@ -465,15 +462,13 @@ DAMAGES.
   If you develop a new library, and you want it to be of the greatest
 possible use to the public, we recommend making it free software that
 everyone can redistribute and change.  You can do so by permitting
-redistribution under these terms (or, alternatively, under the terms
-of the ordinary General Public License).
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
 
-  To apply these terms, attach the following notices to the library.
-It is safest to attach them to the start of each source file to most
-effectively convey the exclusion of warranty; and each file should
-have at least the "copyright" line and a pointer to where the full
-notice is found.
-
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
 
     <one line to give the library's name and a brief idea of what it does.>
     Copyright (C) <year>  <name of author>
@@ -489,22 +484,18 @@ notice is found.
     Lesser General Public License for more details.
 
     You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-You should also get your employer (if you work as a programmer) or
-your school, if any, to sign a "copyright disclaimer" for the library,
-if necessary.  Here is a sample; alter the names:
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
 
   Yoyodyne, Inc., hereby disclaims all copyright interest in the
-  library `Frob' (a library for tweaking knobs) written by James
-  Random Hacker.
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
 
-  <signature of Ty Coon>, 1 April 1990
-  Ty Coon, President of Vice
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
 
 That's all there is to it!
-
-

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 ACLOCAL_AMFLAGS = -I common
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_VERSION=1.11
 AC_VERSION=2.63

--- a/avahi-autoipd/Makefile.am
+++ b/avahi-autoipd/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 if ENABLE_AUTOIPD
 if HAVE_LIBDAEMON

--- a/avahi-autoipd/avahi-autoipd.action.bsd
+++ b/avahi-autoipd/avahi-autoipd.action.bsd
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 set -e
 

--- a/avahi-autoipd/avahi-autoipd.action.linux
+++ b/avahi-autoipd/avahi-autoipd.action.linux
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 set -e
 

--- a/avahi-autoipd/dhclient-enter-hook.in
+++ b/avahi-autoipd/dhclient-enter-hook.in
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 case "$reason" in
     MEDIUM|ARPCHECK|ARPSEND|NBI)

--- a/avahi-autoipd/dhclient-exit-hook.in
+++ b/avahi-autoipd/dhclient-exit-hook.in
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 case "$reason" in
     MEDIUM|ARPCHECK|ARPSEND|NBI)

--- a/avahi-autoipd/iface-bsd.c
+++ b/avahi-autoipd/iface-bsd.c
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-autoipd/iface-linux.c
+++ b/avahi-autoipd/iface-linux.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-autoipd/iface.h
+++ b/avahi-autoipd/iface.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <inttypes.h>

--- a/avahi-autoipd/main.c
+++ b/avahi-autoipd/main.c
@@ -12,8 +12,7 @@
     Public License for more details.
 
     You should have received a copy of the GNU Lesser General Public
-    License along with avahi; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+    License along with avahi; if not, see <https://www.gnu.org/licenses/>.
     USA.
 ***/
 

--- a/avahi-autoipd/main.h
+++ b/avahi-autoipd/main.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 typedef enum Event {

--- a/avahi-client/Makefile.am
+++ b/avahi-client/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-client/browser.c
+++ b/avahi-client/browser.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-client/check-nss-test.c
+++ b/avahi-client/check-nss-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-client/check-nss.c
+++ b/avahi-client/check-nss.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-client/client-test.c
+++ b/avahi-client/client-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-client/client.c
+++ b/avahi-client/client.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-client/client.h
+++ b/avahi-client/client.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <inttypes.h>

--- a/avahi-client/entrygroup.c
+++ b/avahi-client/entrygroup.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-client/internal.h
+++ b/avahi-client/internal.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <dbus/dbus.h>

--- a/avahi-client/lookup.h
+++ b/avahi-client/lookup.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <inttypes.h>

--- a/avahi-client/publish.h
+++ b/avahi-client/publish.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <inttypes.h>

--- a/avahi-client/resolver.c
+++ b/avahi-client/resolver.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-client/rr-test.c
+++ b/avahi-client/rr-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-client/srv-test.c
+++ b/avahi-client/srv-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-client/xdg-config-test.c
+++ b/avahi-client/xdg-config-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-client/xdg-config.c
+++ b/avahi-client/xdg-config.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-client/xdg-config.h
+++ b/avahi-client/xdg-config.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <stdio.h>

--- a/avahi-common/Makefile.am
+++ b/avahi-common/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-common/address.c
+++ b/avahi-common/address.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/address.h
+++ b/avahi-common/address.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file address.h Definitions and functions to manipulate IP addresses. */

--- a/avahi-common/alternative-test.c
+++ b/avahi-common/alternative-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/alternative.c
+++ b/avahi-common/alternative.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/alternative.h
+++ b/avahi-common/alternative.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file alternative.h Functions to find alternative names for hosts and services in the case of name collision */

--- a/avahi-common/cdecl.h
+++ b/avahi-common/cdecl.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file cdecl.h C++ compatibility */

--- a/avahi-common/dbus-watch-glue.c
+++ b/avahi-common/dbus-watch-glue.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/dbus-watch-glue.h
+++ b/avahi-common/dbus-watch-glue.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <dbus/dbus.h>

--- a/avahi-common/dbus.c
+++ b/avahi-common/dbus.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/dbus.h
+++ b/avahi-common/dbus.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file dbus.h Some definitions for the D-Bus interface */

--- a/avahi-common/defs.h
+++ b/avahi-common/defs.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file defs.h Some common definitions */

--- a/avahi-common/domain-test.c
+++ b/avahi-common/domain-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/domain.c
+++ b/avahi-common/domain.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/domain.h
+++ b/avahi-common/domain.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file domain.h Domain name handling functions */

--- a/avahi-common/error.c
+++ b/avahi-common/error.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
  ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/error.h
+++ b/avahi-common/error.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file error.h Error codes and auxiliary functions */

--- a/avahi-common/gccmacro.h
+++ b/avahi-common/gccmacro.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file gccmacro.h Defines some macros for GCC extensions */

--- a/avahi-common/i18n.c
+++ b/avahi-common/i18n.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
  ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/i18n.h
+++ b/avahi-common/i18n.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #if !defined(GETTEXT_PACKAGE)

--- a/avahi-common/llist.h
+++ b/avahi-common/llist.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file llist.h A simple macro based linked list implementation */

--- a/avahi-common/malloc.c
+++ b/avahi-common/malloc.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/malloc.h
+++ b/avahi-common/malloc.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file malloc.h Memory allocation */

--- a/avahi-common/rlist.c
+++ b/avahi-common/rlist.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/rlist.h
+++ b/avahi-common/rlist.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file rlist.h A simple linked list implementation */

--- a/avahi-common/simple-watch.c
+++ b/avahi-common/simple-watch.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/simple-watch.h
+++ b/avahi-common/simple-watch.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file simple-watch.h Simple poll() based main loop implementation */

--- a/avahi-common/strlst-test.c
+++ b/avahi-common/strlst-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/strlst.c
+++ b/avahi-common/strlst.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/strlst.h
+++ b/avahi-common/strlst.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file strlst.h Implementation of a data type to store lists of strings */

--- a/avahi-common/thread-watch.c
+++ b/avahi-common/thread-watch.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/thread-watch.h
+++ b/avahi-common/thread-watch.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file thread-watch.h Threaded poll() based main loop implementation */

--- a/avahi-common/timeval-test.c
+++ b/avahi-common/timeval-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/timeval.c
+++ b/avahi-common/timeval.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/timeval.h
+++ b/avahi-common/timeval.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file timeval.h Functions to facilitate timeval handling */

--- a/avahi-common/utf8-test.c
+++ b/avahi-common/utf8-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/utf8.c
+++ b/avahi-common/utf8.c
@@ -17,9 +17,7 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * License along with this library; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/utf8.h
+++ b/avahi-common/utf8.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <inttypes.h>

--- a/avahi-common/watch-test.c
+++ b/avahi-common/watch-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-common/watch.h
+++ b/avahi-common/watch.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file watch.h Simplistic main loop abstraction */

--- a/avahi-compat-howl/Makefile.am
+++ b/avahi-compat-howl/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-compat-howl/address-test.c
+++ b/avahi-compat-howl/address-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-howl/address.c
+++ b/avahi-compat-howl/address.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-howl/browse-domain-test.c
+++ b/avahi-compat-howl/browse-domain-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-howl/compat.c
+++ b/avahi-compat-howl/compat.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-howl/samples/Makefile.am
+++ b/avahi-compat-howl/samples/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir) -I$(top_srcdir)/avahi-compat-howl/include
 

--- a/avahi-compat-howl/text-test.c
+++ b/avahi-compat-howl/text-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-howl/text.c
+++ b/avahi-compat-howl/text.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-howl/unsupported.c
+++ b/avahi-compat-howl/unsupported.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-howl/warn.c
+++ b/avahi-compat-howl/warn.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-howl/warn.h
+++ b/avahi-compat-howl/warn.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /* To avoid symbol name clashes when a process links to both our

--- a/avahi-compat-libdns_sd/Makefile.am
+++ b/avahi-compat-libdns_sd/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-compat-libdns_sd/compat.c
+++ b/avahi-compat-libdns_sd/compat.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-libdns_sd/null-test.c
+++ b/avahi-compat-libdns_sd/null-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-libdns_sd/txt-test.c
+++ b/avahi-compat-libdns_sd/txt-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-libdns_sd/txt.c
+++ b/avahi-compat-libdns_sd/txt.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-libdns_sd/unsupported.c
+++ b/avahi-compat-libdns_sd/unsupported.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-libdns_sd/warn.c
+++ b/avahi-compat-libdns_sd/warn.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-compat-libdns_sd/warn.h
+++ b/avahi-compat-libdns_sd/warn.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /* This routine works on Linux only, so don't rely on it */

--- a/avahi-core/Makefile.am
+++ b/avahi-core/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-core/addr-util.c
+++ b/avahi-core/addr-util.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/addr-util.h
+++ b/avahi-core/addr-util.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <inttypes.h>

--- a/avahi-core/announce.c
+++ b/avahi-core/announce.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/announce.h
+++ b/avahi-core/announce.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 typedef struct AvahiAnnouncer AvahiAnnouncer;

--- a/avahi-core/avahi-reflector.c
+++ b/avahi-core/avahi-reflector.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/avahi-test.c
+++ b/avahi-core/avahi-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/browse-dns-server.c
+++ b/avahi-core/browse-dns-server.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/browse-domain.c
+++ b/avahi-core/browse-domain.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/browse-service-type.c
+++ b/avahi-core/browse-service-type.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/browse-service.c
+++ b/avahi-core/browse-service.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/browse.c
+++ b/avahi-core/browse.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/browse.h
+++ b/avahi-core/browse.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <avahi-common/llist.h>

--- a/avahi-core/cache.c
+++ b/avahi-core/cache.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/cache.h
+++ b/avahi-core/cache.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 typedef struct AvahiCache AvahiCache;

--- a/avahi-core/cname-test.c
+++ b/avahi-core/cname-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/conformance-test.c
+++ b/avahi-core/conformance-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/core.h
+++ b/avahi-core/core.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file core.h The Avahi Multicast DNS and DNS Service Discovery implementation. */

--- a/avahi-core/dns-spin-test.c
+++ b/avahi-core/dns-spin-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /* Regression test for Avahi bug #84.

--- a/avahi-core/dns-srv-rr.h
+++ b/avahi-core/dns-srv-rr.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file avahi-core/dns-srv-rr.h Functions for announcing and browsing for unicast DNS servers via mDNS */

--- a/avahi-core/dns-test.c
+++ b/avahi-core/dns-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/dns.c
+++ b/avahi-core/dns.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/dns.h
+++ b/avahi-core/dns.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include "rr.h"

--- a/avahi-core/domain-util.c
+++ b/avahi-core/domain-util.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/domain-util.h
+++ b/avahi-core/domain-util.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <inttypes.h>

--- a/avahi-core/entry.c
+++ b/avahi-core/entry.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/fdutil.c
+++ b/avahi-core/fdutil.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/fdutil.h
+++ b/avahi-core/fdutil.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <avahi-common/cdecl.h>

--- a/avahi-core/hashmap-test.c
+++ b/avahi-core/hashmap-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/hashmap.c
+++ b/avahi-core/hashmap.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/hashmap.h
+++ b/avahi-core/hashmap.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <avahi-common/cdecl.h>

--- a/avahi-core/iface-linux.c
+++ b/avahi-core/iface-linux.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/iface-linux.h
+++ b/avahi-core/iface-linux.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 typedef struct AvahiInterfaceMonitorOSDep AvahiInterfaceMonitorOSDep;

--- a/avahi-core/iface-none.c
+++ b/avahi-core/iface-none.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include "iface.h"

--- a/avahi-core/iface-pfroute.c
+++ b/avahi-core/iface-pfroute.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/iface-pfroute.h
+++ b/avahi-core/iface-pfroute.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 #include <avahi-common/watch.h>
 

--- a/avahi-core/iface.c
+++ b/avahi-core/iface.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/iface.h
+++ b/avahi-core/iface.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 typedef struct AvahiInterfaceMonitor AvahiInterfaceMonitor;

--- a/avahi-core/internal.h
+++ b/avahi-core/internal.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** A locally registered DNS resource record */

--- a/avahi-core/log.c
+++ b/avahi-core/log.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/log.h
+++ b/avahi-core/log.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <stdarg.h>

--- a/avahi-core/lookup.h
+++ b/avahi-core/lookup.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file avahi-core/lookup.h Functions for browsing/resolving services and other RRs */

--- a/avahi-core/multicast-lookup.c
+++ b/avahi-core/multicast-lookup.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/multicast-lookup.h
+++ b/avahi-core/multicast-lookup.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include "lookup.h"

--- a/avahi-core/netlink.c
+++ b/avahi-core/netlink.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/netlink.h
+++ b/avahi-core/netlink.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <sys/socket.h>

--- a/avahi-core/prioq-test.c
+++ b/avahi-core/prioq-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/prioq.c
+++ b/avahi-core/prioq.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/prioq.h
+++ b/avahi-core/prioq.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 typedef struct AvahiPrioQueue AvahiPrioQueue;

--- a/avahi-core/probe-sched.c
+++ b/avahi-core/probe-sched.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/probe-sched.h
+++ b/avahi-core/probe-sched.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 typedef struct AvahiProbeScheduler AvahiProbeScheduler;

--- a/avahi-core/publish.h
+++ b/avahi-core/publish.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file core/publish.h Functions for publising local services and RRs */

--- a/avahi-core/querier-test.c
+++ b/avahi-core/querier-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/querier.c
+++ b/avahi-core/querier.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/querier.h
+++ b/avahi-core/querier.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 typedef struct AvahiQuerier AvahiQuerier;

--- a/avahi-core/query-sched.c
+++ b/avahi-core/query-sched.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/query-sched.h
+++ b/avahi-core/query-sched.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 typedef struct AvahiQueryScheduler AvahiQueryScheduler;

--- a/avahi-core/resolve-address.c
+++ b/avahi-core/resolve-address.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/resolve-host-name.c
+++ b/avahi-core/resolve-host-name.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/resolve-service.c
+++ b/avahi-core/resolve-service.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/response-sched.c
+++ b/avahi-core/response-sched.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/response-sched.h
+++ b/avahi-core/response-sched.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 typedef struct AvahiResponseScheduler AvahiResponseScheduler;

--- a/avahi-core/rr-util.h
+++ b/avahi-core/rr-util.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include "rr.h"

--- a/avahi-core/rr.c
+++ b/avahi-core/rr.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/rr.h
+++ b/avahi-core/rr.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file rr.h Functions and definitions for manipulating DNS resource record (RR) data. */

--- a/avahi-core/rrlist.c
+++ b/avahi-core/rrlist.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/rrlist.h
+++ b/avahi-core/rrlist.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 

--- a/avahi-core/server.c
+++ b/avahi-core/server.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/socket.c
+++ b/avahi-core/socket.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/socket.h
+++ b/avahi-core/socket.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <inttypes.h>

--- a/avahi-core/timeeventq-test.c
+++ b/avahi-core/timeeventq-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/timeeventq.c
+++ b/avahi-core/timeeventq.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/timeeventq.h
+++ b/avahi-core/timeeventq.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <sys/types.h>

--- a/avahi-core/update-test.c
+++ b/avahi-core/update-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/util.c
+++ b/avahi-core/util.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/util.h
+++ b/avahi-core/util.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <inttypes.h>

--- a/avahi-core/wide-area.c
+++ b/avahi-core/wide-area.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-core/wide-area.h
+++ b/avahi-core/wide-area.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include "lookup.h"

--- a/avahi-daemon/Makefile.am
+++ b/avahi-daemon/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-daemon/avahi-daemon.conf
+++ b/avahi-daemon/avahi-daemon.conf
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 # See avahi-daemon.conf(5) for more information on this configuration
 # file!

--- a/avahi-daemon/avahi-daemon.service.in
+++ b/avahi-daemon/avahi-daemon.service.in
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 [Unit]
 Description=Avahi mDNS/DNS-SD Stack

--- a/avahi-daemon/avahi-daemon.socket.in
+++ b/avahi-daemon/avahi-daemon.socket.in
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 [Unit]
 Description=Avahi mDNS/DNS-SD Stack Activation Socket

--- a/avahi-daemon/caps.c
+++ b/avahi-daemon/caps.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/caps.h
+++ b/avahi-daemon/caps.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 int avahi_caps_reduce(void);

--- a/avahi-daemon/chroot.c
+++ b/avahi-daemon/chroot.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/chroot.h
+++ b/avahi-daemon/chroot.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <stdio.h>

--- a/avahi-daemon/dbus-async-address-resolver.c
+++ b/avahi-daemon/dbus-async-address-resolver.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-async-host-name-resolver.c
+++ b/avahi-daemon/dbus-async-host-name-resolver.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-async-service-resolver.c
+++ b/avahi-daemon/dbus-async-service-resolver.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-domain-browser.c
+++ b/avahi-daemon/dbus-domain-browser.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-entry-group.c
+++ b/avahi-daemon/dbus-entry-group.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-internal.h
+++ b/avahi-daemon/dbus-internal.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 

--- a/avahi-daemon/dbus-protocol.c
+++ b/avahi-daemon/dbus-protocol.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-protocol.h
+++ b/avahi-daemon/dbus-protocol.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 int dbus_protocol_setup(const AvahiPoll *poll_api,

--- a/avahi-daemon/dbus-record-browser.c
+++ b/avahi-daemon/dbus-record-browser.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-service-browser.c
+++ b/avahi-daemon/dbus-service-browser.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-service-type-browser.c
+++ b/avahi-daemon/dbus-service-type-browser.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-sync-address-resolver.c
+++ b/avahi-daemon/dbus-sync-address-resolver.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-sync-host-name-resolver.c
+++ b/avahi-daemon/dbus-sync-host-name-resolver.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-sync-service-resolver.c
+++ b/avahi-daemon/dbus-sync-service-resolver.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-util.c
+++ b/avahi-daemon/dbus-util.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/dbus-util.h
+++ b/avahi-daemon/dbus-util.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <inttypes.h>

--- a/avahi-daemon/example.service
+++ b/avahi-daemon/example.service
@@ -15,9 +15,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <!-- See avahi.service(5) for more information about this configuration file -->

--- a/avahi-daemon/hosts
+++ b/avahi-daemon/hosts
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 # This file contains static ip address <-> host name mappings.  These
 # can be useful to publish services on behalf of a non-avahi enabled

--- a/avahi-daemon/ini-file-parser-test.c
+++ b/avahi-daemon/ini-file-parser-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/ini-file-parser.c
+++ b/avahi-daemon/ini-file-parser.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/ini-file-parser.h
+++ b/avahi-daemon/ini-file-parser.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <avahi-common/llist.h>

--- a/avahi-daemon/introspect.xsl
+++ b/avahi-daemon/introspect.xsl
@@ -15,8 +15,7 @@
   for more details.
 
   You should have received a copy of the GNU General Public License
-  along with avahi; if not, write to the Free Software Foundation,
-  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA. 
+  along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <xsl:output method="xml" version="1.0" encoding="iso-8859-15" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd" indent="yes"/>

--- a/avahi-daemon/main.c
+++ b/avahi-daemon/main.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/main.h
+++ b/avahi-daemon/main.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <avahi-core/core.h>

--- a/avahi-daemon/org.freedesktop.Avahi.AddressResolver.xml
+++ b/avahi-daemon/org.freedesktop.Avahi.AddressResolver.xml
@@ -16,9 +16,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>

--- a/avahi-daemon/org.freedesktop.Avahi.DomainBrowser.xml
+++ b/avahi-daemon/org.freedesktop.Avahi.DomainBrowser.xml
@@ -16,9 +16,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>

--- a/avahi-daemon/org.freedesktop.Avahi.EntryGroup.xml
+++ b/avahi-daemon/org.freedesktop.Avahi.EntryGroup.xml
@@ -16,9 +16,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>

--- a/avahi-daemon/org.freedesktop.Avahi.HostNameResolver.xml
+++ b/avahi-daemon/org.freedesktop.Avahi.HostNameResolver.xml
@@ -16,9 +16,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>

--- a/avahi-daemon/org.freedesktop.Avahi.RecordBrowser.xml
+++ b/avahi-daemon/org.freedesktop.Avahi.RecordBrowser.xml
@@ -16,9 +16,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>

--- a/avahi-daemon/org.freedesktop.Avahi.Server.xml
+++ b/avahi-daemon/org.freedesktop.Avahi.Server.xml
@@ -16,9 +16,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>

--- a/avahi-daemon/org.freedesktop.Avahi.ServiceBrowser.xml
+++ b/avahi-daemon/org.freedesktop.Avahi.ServiceBrowser.xml
@@ -16,9 +16,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>

--- a/avahi-daemon/org.freedesktop.Avahi.ServiceResolver.xml
+++ b/avahi-daemon/org.freedesktop.Avahi.ServiceResolver.xml
@@ -16,9 +16,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>

--- a/avahi-daemon/org.freedesktop.Avahi.ServiceTypeBrowser.xml
+++ b/avahi-daemon/org.freedesktop.Avahi.ServiceTypeBrowser.xml
@@ -16,9 +16,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <node>

--- a/avahi-daemon/org.freedesktop.Avahi.service
+++ b/avahi-daemon/org.freedesktop.Avahi.service
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 [D-BUS Service]
 Name=org.freedesktop.Avahi

--- a/avahi-daemon/setproctitle.c
+++ b/avahi-daemon/setproctitle.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/setproctitle.h
+++ b/avahi-daemon/setproctitle.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <avahi-common/gccmacro.h>

--- a/avahi-daemon/sftp-ssh.service
+++ b/avahi-daemon/sftp-ssh.service
@@ -15,9 +15,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <!-- See avahi.service(5) for more information about this configuration file -->

--- a/avahi-daemon/simple-protocol.c
+++ b/avahi-daemon/simple-protocol.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/simple-protocol.h
+++ b/avahi-daemon/simple-protocol.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <avahi-common/watch.h>

--- a/avahi-daemon/ssh.service
+++ b/avahi-daemon/ssh.service
@@ -15,9 +15,7 @@
   General Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-  02111-1307 USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <!-- See avahi.service(5) for more information about this configuration file -->

--- a/avahi-daemon/static-hosts.c
+++ b/avahi-daemon/static-hosts.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/static-hosts.h
+++ b/avahi-daemon/static-hosts.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 void static_hosts_load(int in_chroot);

--- a/avahi-daemon/static-services.c
+++ b/avahi-daemon/static-services.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-daemon/static-services.h
+++ b/avahi-daemon/static-services.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 void static_service_load(int in_chroot);

--- a/avahi-discover-standalone/Makefile.am
+++ b/avahi-discover-standalone/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-discover-standalone/main.c
+++ b/avahi-discover-standalone/main.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-dnsconfd/Makefile.am
+++ b/avahi-dnsconfd/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 EXTRA_DIST=avahi-dnsconfd.action avahi-dnsconfd.service.in
 

--- a/avahi-dnsconfd/avahi-dnsconfd.action
+++ b/avahi-dnsconfd/avahi-dnsconfd.action
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 set -e
 

--- a/avahi-dnsconfd/avahi-dnsconfd.service.in
+++ b/avahi-dnsconfd/avahi-dnsconfd.service.in
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 [Unit]
 Description=Avahi DNS Configuration Daemon

--- a/avahi-dnsconfd/main.c
+++ b/avahi-dnsconfd/main.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-glib/Makefile.am
+++ b/avahi-glib/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-glib/glib-malloc.c
+++ b/avahi-glib/glib-malloc.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-glib/glib-malloc.h
+++ b/avahi-glib/glib-malloc.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file glib-malloc.h GLib's memory allocator for Avahi */

--- a/avahi-glib/glib-watch-test.c
+++ b/avahi-glib/glib-watch-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-glib/glib-watch.c
+++ b/avahi-glib/glib-watch.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-glib/glib-watch.h
+++ b/avahi-glib/glib-watch.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file glib-watch.h GLib main loop adapter */

--- a/avahi-gobject/Makefile.am
+++ b/avahi-gobject/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-libevent/Makefile.am
+++ b/avahi-libevent/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-libevent/libevent-watch-test.c
+++ b/avahi-libevent/libevent-watch-test.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-libevent/libevent-watch.c
+++ b/avahi-libevent/libevent-watch.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-libevent/libevent-watch.h
+++ b/avahi-libevent/libevent-watch.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file libevent-watch.h libevent main loop adapter */

--- a/avahi-python/Makefile.am
+++ b/avahi-python/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-python/avahi-bookmarks.in
+++ b/avahi-python/avahi-bookmarks.in
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 import sys, getopt, os
 

--- a/avahi-python/avahi-discover/Makefile.am
+++ b/avahi-python/avahi-discover/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-python/avahi-discover/avahi-discover.py
+++ b/avahi-python/avahi-discover/avahi-discover.py
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function
 

--- a/avahi-python/avahi/Makefile.am
+++ b/avahi-python/avahi/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 EXTRA_DIST = __init__.py ServiceTypeDatabase.py.in
 EXTRA_DIST += test.py

--- a/avahi-python/avahi/ServiceTypeDatabase.py.in
+++ b/avahi-python/avahi/ServiceTypeDatabase.py.in
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 try:
     import anydbm as dbm

--- a/avahi-python/avahi/__init__.py
+++ b/avahi-python/avahi/__init__.py
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 # Some definitions matching those in avahi-common/defs.h
 

--- a/avahi-python/avahi/test.py
+++ b/avahi-python/avahi/test.py
@@ -15,9 +15,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 import os
 import os.path

--- a/avahi-qt/Makefile.am
+++ b/avahi-qt/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-qt/qt-watch.cpp
+++ b/avahi-qt/qt-watch.cpp
@@ -12,9 +12,7 @@
   Public License for more details.
  
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <sys/time.h>

--- a/avahi-qt/qt-watch.h
+++ b/avahi-qt/qt-watch.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 /** \file qt-watch.h Qt main loop adapter */

--- a/avahi-sharp/AddressResolver.cs
+++ b/avahi-sharp/AddressResolver.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System;

--- a/avahi-sharp/AssemblyInfo.cs
+++ b/avahi-sharp/AssemblyInfo.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System.Reflection;

--- a/avahi-sharp/AvahiTest.cs
+++ b/avahi-sharp/AvahiTest.cs
@@ -12,8 +12,7 @@
     Public License for more details.
 
     You should have received a copy of the GNU Lesser General Public
-    License along with avahi; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+    License along with avahi; if not, see <https://www.gnu.org/licenses/>.
     USA.
 ***/
 

--- a/avahi-sharp/BrowserBase.cs
+++ b/avahi-sharp/BrowserBase.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System;

--- a/avahi-sharp/Client.cs
+++ b/avahi-sharp/Client.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 

--- a/avahi-sharp/ClientException.cs
+++ b/avahi-sharp/ClientException.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 

--- a/avahi-sharp/DomainBrowser.cs
+++ b/avahi-sharp/DomainBrowser.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System;

--- a/avahi-sharp/EntryGroup.cs
+++ b/avahi-sharp/EntryGroup.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System;

--- a/avahi-sharp/HostNameResolver.cs
+++ b/avahi-sharp/HostNameResolver.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System;

--- a/avahi-sharp/Makefile.am
+++ b/avahi-sharp/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 ASSEMBLY = avahi-sharp.dll
 

--- a/avahi-sharp/RecordBrowser.cs
+++ b/avahi-sharp/RecordBrowser.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System;

--- a/avahi-sharp/ResolverBase.cs
+++ b/avahi-sharp/ResolverBase.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System;

--- a/avahi-sharp/ServiceBrowser.cs
+++ b/avahi-sharp/ServiceBrowser.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System;

--- a/avahi-sharp/ServiceResolver.cs
+++ b/avahi-sharp/ServiceResolver.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System;

--- a/avahi-sharp/ServiceTypeBrowser.cs
+++ b/avahi-sharp/ServiceTypeBrowser.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System;

--- a/avahi-sharp/Utility.cs
+++ b/avahi-sharp/Utility.cs
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 using System;

--- a/avahi-ui-sharp/Makefile.am
+++ b/avahi-ui-sharp/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 ASSEMBLY = avahi-ui-sharp.dll
 

--- a/avahi-ui/Makefile.am
+++ b/avahi-ui/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-ui/avahi-ui.c
+++ b/avahi-ui/avahi-ui.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-ui/avahi-ui.h
+++ b/avahi-ui/avahi-ui.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <gtk/gtk.h>

--- a/avahi-ui/bssh.c
+++ b/avahi-ui/bssh.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-utils/Makefile.am
+++ b/avahi-utils/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/avahi-utils/avahi-browse.c
+++ b/avahi-utils/avahi-browse.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-utils/avahi-publish.c
+++ b/avahi-utils/avahi-publish.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-utils/avahi-resolve.c
+++ b/avahi-utils/avahi-resolve.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-utils/avahi-set-host-name.c
+++ b/avahi-utils/avahi-set-host-name.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-utils/sigint.c
+++ b/avahi-utils/sigint.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/avahi-utils/sigint.h
+++ b/avahi-utils/sigint.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <avahi-common/simple-watch.h>

--- a/avahi-utils/stdb.c
+++ b/avahi-utils/stdb.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <config.h>

--- a/avahi-utils/stdb.h
+++ b/avahi-utils/stdb.h
@@ -15,9 +15,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <avahi-common/simple-watch.h>

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 FLAGS="--sysconfdir=/etc --localstatedir=/var --enable-tests --enable-compat-howl --enable-compat-libdns_sd"
 export MAKE="make"

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 EXTRA_DIST = gettext.m4 iconv.m4 lib-ld.m4 lib-link.m4 lib-prefix.m4 nls.m4 po.m4 progtest.m4 \
 	doxygen.m4 \

--- a/configure.ac
+++ b/configure.ac
@@ -14,9 +14,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AC_PREREQ(2.63)
 AC_INIT([avahi],[0.9-rc3],[avahi (at) lists (dot) freedesktop (dot) org])

--- a/docs/HACKING
+++ b/docs/HACKING
@@ -50,9 +50,7 @@ Please comply with the following rules when hacking on Avahi:
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 </snip>
 
    For C source code:
@@ -72,8 +70,6 @@ Please comply with the following rules when hacking on Avahi:
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 </snip>

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS=-I$(top_srcdir)
 

--- a/examples/client-browse-services.c
+++ b/examples/client-browse-services.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/examples/client-publish-service.c
+++ b/examples/client-publish-service.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/examples/core-browse-services.c
+++ b/examples/core-browse-services.c
@@ -23,9 +23,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/examples/core-publish-service.c
+++ b/examples/core-publish-service.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/examples/glib-integration.c
+++ b/examples/glib-integration.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/fuzz/fuzz-consume-key.c
+++ b/fuzz/fuzz-consume-key.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <stdint.h>

--- a/fuzz/fuzz-consume-record.c
+++ b/fuzz/fuzz-consume-record.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <stdint.h>

--- a/fuzz/fuzz-domain.c
+++ b/fuzz/fuzz-domain.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <assert.h>

--- a/fuzz/fuzz-ini-file-parser.c
+++ b/fuzz/fuzz-ini-file-parser.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <assert.h>

--- a/fuzz/fuzz-packet.c
+++ b/fuzz/fuzz-packet.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <stdbool.h>

--- a/fuzz/fuzz-strlst.c
+++ b/fuzz/fuzz-strlst.c
@@ -12,9 +12,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #include <assert.h>

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 # This script can be run using docker and the OSS-Fuzz toolchain:
 # https://google.github.io/oss-fuzz/advanced-topics/reproducing/#building-using-docker

--- a/initscript/Makefile.am
+++ b/initscript/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 SUBDIRS =
 

--- a/initscript/darwin/Makefile.am
+++ b/initscript/darwin/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 initddir = /Library/LaunchDaemons/
 

--- a/initscript/gentoo/Makefile.am
+++ b/initscript/gentoo/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 if !HAVE_DBUS
 NO_DBUS_DEPENDENCY=/need dbus/d

--- a/initscript/slackware/Makefile.am
+++ b/initscript/slackware/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 initddir = $(sysconfdir)/rc.d
 

--- a/initscript/slackware/avahi-daemon.in
+++ b/initscript/slackware/avahi-daemon.in
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 # Start/stop/restart the avahi daemon:
 

--- a/initscript/slackware/avahi-dnsconfd.in
+++ b/initscript/slackware/avahi-dnsconfd.in
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 # Start/stop/restart the avahi dnsconfd daemon:
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 pkgsysconfdir=$(sysconfdir)/avahi
 servicedir=$(pkgsysconfdir)/services

--- a/man/avahi-autoipd.8.xml.in
+++ b/man/avahi-autoipd.8.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi-autoipd" section="8" desc="IPv4LL network address configuration daemon">

--- a/man/avahi-autoipd.action.8.xml.in
+++ b/man/avahi-autoipd.action.8.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi-autoipd.action" section="8" desc="avahi-autoipd action script">

--- a/man/avahi-bookmarks.1.xml.in
+++ b/man/avahi-bookmarks.1.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi-bookmarks" section="1" desc="Web service showing mDNS/DNS-SD announced HTTP services using the Avahi daemon">

--- a/man/avahi-browse.1.xml.in
+++ b/man/avahi-browse.1.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi-browse" section="1" desc="Browse for mDNS/DNS-SD services using the Avahi daemon">

--- a/man/avahi-daemon.8.xml.in
+++ b/man/avahi-daemon.8.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi-daemon" section="8" desc="The Avahi mDNS/DNS-SD daemon">

--- a/man/avahi-daemon.conf.5.xml.in
+++ b/man/avahi-daemon.conf.5.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <manpage name="avahi-daemon.conf" section="5" desc="avahi-daemon configuration file">

--- a/man/avahi-discover.1.xml.in
+++ b/man/avahi-discover.1.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi-discover" section="1" desc="Browse for mDNS/DNS-SD services using the Avahi daemon">

--- a/man/avahi-dnsconfd.8.xml.in
+++ b/man/avahi-dnsconfd.8.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi-dnsconfd" section="8" desc="Unicast DNS server from mDNS/DNS-SD configuration daemon">

--- a/man/avahi-dnsconfd.action.8.xml.in
+++ b/man/avahi-dnsconfd.action.8.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi-dnsconfd.action" section="8" desc="avahi-dnsconfd action script">

--- a/man/avahi-publish.1.xml.in
+++ b/man/avahi-publish.1.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi-publish-service" section="1" desc="Register an mDNS/DNS-SD service or host name or address mapping using the Avahi daemon">

--- a/man/avahi-resolve.1.xml.in
+++ b/man/avahi-resolve.1.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi-resolve" section="1" desc="Resolve one or more mDNS/DNS host name(s) to IP address(es) (and vice versa) using the Avahi daemon">

--- a/man/avahi-set-host-name.1.xml.in
+++ b/man/avahi-set-host-name.1.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi-set-host-name" section="1" desc="Change mDNS host name">

--- a/man/avahi.hosts.5.xml.in
+++ b/man/avahi.hosts.5.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi.hosts" section="5" desc="avahi-daemon static host name file">

--- a/man/avahi.service.5.xml.in
+++ b/man/avahi.service.5.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="avahi.service" section="5" desc="avahi-daemon static service file">

--- a/man/bssh.1.xml.in
+++ b/man/bssh.1.xml.in
@@ -16,9 +16,7 @@
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
   <manpage name="bssh/bvnc/bshell" section="1" desc="Browse for SSH/VNC servers on the local network">

--- a/man/xmltoman.css
+++ b/man/xmltoman.css
@@ -12,8 +12,7 @@
   for more details.
 
   You should have received a copy of the GNU General Public License
-  along with avahi; if not, write to the Free Software Foundation,
-  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA. 
+  along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 body { color: black; background-color: white; } 

--- a/man/xmltoman.dtd
+++ b/man/xmltoman.dtd
@@ -12,8 +12,7 @@
   for more details.
 
   You should have received a copy of the GNU General Public License
-  along with avahi; if not, write to the Free Software Foundation,
-  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+  along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <!ELEMENT manpage (synopsis | description | section | options | seealso)*>

--- a/man/xmltoman.xsl
+++ b/man/xmltoman.xsl
@@ -15,8 +15,7 @@
   for more details.
 
   You should have received a copy of the GNU General Public License
-  along with avahi; if not, write to the Free Software Foundation,
-  Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA. 
+  along with avahi; if not, see <https://www.gnu.org/licenses/>.
 -->
 
 <xsl:output method="xml" version="1.0" encoding="iso-8859-15" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd" indent="yes"/>

--- a/service-type-database/Makefile.am
+++ b/service-type-database/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 EXTRA_DIST=service-types
 

--- a/service-type-database/build-db
+++ b/service-type-database/build-db
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 import sys
 

--- a/service-type-database/service-types
+++ b/service-type-database/service-types
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 # Feel free to add more service types or translatons to this database.
 # Please refrain from copying bulk service type data from any publicly

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,9 +11,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 AM_CFLAGS= \
 	-I$(top_srcdir)

--- a/tests/c-plus-plus-test-gen.py
+++ b/tests/c-plus-plus-test-gen.py
@@ -13,9 +13,7 @@
 # License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
-# License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 
 import os, sys
 
@@ -43,9 +41,7 @@ print """/***
   Public License for more details.
 
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H

--- a/tests/c-plus-plus-test.cc
+++ b/tests/c-plus-plus-test.cc
@@ -12,9 +12,7 @@
   Public License for more details.
  
   You should have received a copy of the GNU Lesser General Public
-  License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-  USA.
+  License along with avahi; if not, see <https://www.gnu.org/licenses/>.
 ***/
 
 #ifdef HAVE_CONFIG_H


### PR DESCRIPTION
```
    Fixed with following sed script:
    s|License along with avahi; if not, see <https://www.gnu.org/licenses/>.|License along with avahi; if not, see <https://www.gnu.org/licenses/>.|
    /^[# ] Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307/ d
    /^[# ] USA./ d
    s|along with avahi; if not, see <https://www.gnu.org/licenses/>.|along with avahi; if not, see <https://www.gnu.org/licenses/>.|
    /^[# ] Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA./ d
    /^[# ] Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA/ d
    /^[# ] 02111-1307 USA./ d
```