### PR TITLE
ci: run the ini-file-parser test under Valgrind as well

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -37,7 +37,7 @@ dump_journal() {
 run() {
     local cmd=()
 
-    if [[ "$VALGRIND" == true && "$1" =~ avahi ]]; then
+    if [[ "$VALGRIND" == true && "$1" =~ (avahi|ini-file-parser-test) ]]; then
         if [[ "$1" =~ ^\. ]]; then
             cmd+=("libtool" "--mode=execute")
         fi


### PR DESCRIPTION
run looks for "avahi" to avoid running external commands like drill under Valgrind and it prevents ini-file-parser-test from being run under Valgrind as well. It's not ideal because the Valgrind job misses issues like:
```
==36036== Invalid read of size 8
==36036==    at 0x4002741: avahi_strfreev (ini-file-parser.c:292)
==36036==    by 0x4002691: avahi_ini_list_confd_files_sorted (ini-file-parser.c:119)
==36036==    by 0x4004F5A: avahi_ini_load_all_config (ini-file-parser.c:786)
==36036==    by 0x4005EB2: test_confd_load_all_config (ini-file-parser-test.c:299)
==36036==    by 0x400623F: test_confd_too_many_files (ini-file-parser-test.c:393)
==36036==    by 0x4006E19: main (ini-file-parser-test.c:749)
```
in PRs.