### PR TITLE
ci: make sure avahi with no D-Bus is buildable

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -3,6 +3,7 @@
 set -eux
 set -o pipefail
 
+export ADDITIONAL_AUTOGEN_ARGS=${ADDITIONAL_AUTOGEN_ARGS:-}
 export ASAN_UBSAN=${ASAN_UBSAN:-false}
 export BUILD_ONLY=${BUILD_ONLY:-false}
 export CFLAGS=${CFLAGS:-"-g -O0"}
@@ -293,6 +294,9 @@ case "$1" in
                 "--sysconfdir=/etc"
             )
         fi
+
+        IFS=" " read -r -a additional_autogen_args <<<"$ADDITIONAL_AUTOGEN_ARGS"
+        autogen_args+=("${additional_autogen_args[@]}")
 
         if [[ "$OS" =~ (netbsd|omnios) ]]; then
             # On NetBSD and OmniOS autogen.sh fails with

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
           - { CC: "gcc", ASAN_UBSAN: "false", CFLAGS: "-g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -fno-omit-frame-pointer" }
           - { CC: "clang", ASAN_UBSAN: "false" }
           - { CC: "clang", ASAN_UBSAN: "true" }
+        include:
+          - runner: ubuntu-24.04
+            env: { CC: "gcc", BUILD_ONLY: "true", ADDITIONAL_AUTOGEN_ARGS: "--disable-dbus" }
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout


### PR DESCRIPTION
to cover a relatively common non-desktop use case. It's prompted by a PR where a broken non-D-Bus build wasn't spotted by the CI.