### PR TITLE
ci: adjust libdaemon syslog fd valgrind suppression

### DIFF
--- a/.github/workflows/avahi-daemon.supp
+++ b/.github/workflows/avahi-daemon.supp
@@ -10,6 +10,7 @@
 {
    libdaemon-syslog
    CoreError:FdNotClosed
+   ...
    fun:socket
    ...
    fun:daemon_log


### PR DESCRIPTION
to also cover track-fd Valgrind backtraces like
```
==60027== Open AF_UNIX socket 4: <unknown>
==60027==    at 0x401C302: _dl_sysinfo_int80 (in /usr/lib/i386-linux-gnu/ld-linux.so.2)
==60027==    by 0x4BA13F2: socket (socket.c:27)
==60027==    by 0x4B9B5A8: openlog_internal (syslog.c:349)
==60027==    by 0x4B9BCED: __vsyslog_internal (syslog.c:281)
==60027==    by 0x48B35BD: daemon_logv (in /usr/lib/i386-linux-gnu/libdaemon.so.0.5.0)
==60027==    by 0x48B3683: daemon_log (in /usr/lib/i386-linux-gnu/libdaemon.so.0.5.0)
==60027==    by 0x10E0CD: log_function (main.c:503)
==60027==    by 0x4899E91: avahi_log_ap (log.c:41)
==60027==    by 0x4899FC6: avahi_log_info (log.c:77)
==60027==    by 0x10F6AA: main (main.c:1281)
```