### PR TITLE
ci: turn off s390x jobs on Packit for now

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -29,7 +29,8 @@ jobs:
   - fedora-all-aarch64
   - fedora-all-i386
   - fedora-all-ppc64le
-  - fedora-all-s390x
+# https://github.com/fedora-copr/copr/issues/4219
+# - fedora-all-s390x
   - fedora-all-x86_64
 - job: copr_build
   trigger: commit
@@ -37,5 +38,6 @@ jobs:
   - fedora-all-aarch64
   - fedora-all-i386
   - fedora-all-ppc64le
-  - fedora-all-s390x
+# https://github.com/fedora-copr/copr/issues/4219
+# - fedora-all-s390x
   - fedora-all-x86_64


### PR DESCRIPTION
They get stuck because of
https://github.com/fedora-copr/copr/issues/4219 and should be brought back once that issue is resolved.