### PR TITLE
CVE-2025-59529: simple protocol connection limits with review fixes and tests

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -235,20 +235,27 @@ test_simple_protocol_limits() {
     _saved_rlimit=$(perl -lne 'print $1 if /^(#?rlimit-nofile=.*)/' "$avahi_daemon_conf")
     sed -i.bak 's|^#*rlimit-nofile=.*|rlimit-nofile=100|' "$avahi_daemon_conf"
 
-    # Ensure config is restored and flood connections are cleaned up
-    # on any exit, including set -e failures.
     trap '_simple_protocol_limits_cleanup' EXIT
 
     if [[ "$WITH_SYSTEMD" == true ]]; then
+        # systemd's LimitNOFILE overrides the daemon config
+        mkdir -p /run/systemd/system/avahi-daemon.service.d
+        printf '[Service]\nLimitNOFILE=100\n' \
+            > /run/systemd/system/avahi-daemon.service.d/test-rlimit.conf
+        systemctl daemon-reload
         run systemctl restart avahi-daemon
     elif [[ "$VALGRIND" == true ]]; then
         avahi-daemon --kill 2>/dev/null || true
         sleep 1
+        # Set RLIMIT_NOFILE before Valgrind starts; Valgrind
+        # intercepts setrlimit() so the daemon config alone
+        # is not enough.
+        (ulimit -n 100 && \
         valgrind --log-file="$valgrind_log_file" --leak-check=full \
             --track-origins=yes --track-fds=yes --error-exitcode=1 \
             --trace-children=yes \
             -s --suppressions=.github/workflows/avahi-daemon.supp \
-            avahi-daemon -D --debug --no-drop-root --no-proc-title
+            avahi-daemon -D --debug --no-drop-root --no-proc-title)
     elif [[ "$ASAN_UBSAN" == true ]]; then
         avahi-daemon --kill 2>/dev/null || true
         sleep 1
@@ -260,7 +267,9 @@ test_simple_protocol_limits() {
         sleep 1
         avahi-daemon -D --debug
     fi
-    # Allow daemon to finish startup and bind the socket
+    if [[ "$WITH_SYSTEMD" == false ]]; then
+        avahi-dnsconfd -D 2>/dev/null || true
+    fi
     sleep 2
 
     _pid=$(cat "$avahi_daemon_pid_file")
@@ -372,6 +381,9 @@ test_simple_protocol_limits() {
         sleep 1
         avahi-daemon -D --debug
     fi
+    if [[ "$WITH_SYSTEMD" == false ]]; then
+        avahi-dnsconfd -D 2>/dev/null || true
+    fi
     sleep 2
 }
 
@@ -390,6 +402,9 @@ _simple_protocol_limits_cleanup() {
         sed -i.bak '/^rlimit-nofile=100/d' "$avahi_daemon_conf"
     fi
     rm -f "${avahi_daemon_conf}.bak"
+
+    rm -f /run/systemd/system/avahi-daemon.service.d/test-rlimit.conf 2>/dev/null
+    systemctl daemon-reload 2>/dev/null || true
 }
 
 _simple_protocol_limits_count() {
@@ -515,7 +530,7 @@ run drill -p5353 @127.0.0.1 _domain._udp.local ANY
 drill -Q -p5353 @127.0.0.1 "$l._ssh._tcp.local" TXT | grep org.freedesktop.Avahi.cookie
 
 if [[ "$WITH_SYSTEMD" == false ]]; then
-    run avahi-dnsconfd --kill
+    avahi-dnsconfd --kill 2>/dev/null || true
 
     pid=$(cat "$avahi_daemon_pid_file")
     run avahi-daemon --kill

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -219,6 +219,199 @@ check_rlimit_nofile() {
     [[ "$_rlimit_nofile" == "$_rlimit_nofile_conf" ]]
 }
 
+# CVE-2025-59529: Test simple protocol client connection limits.
+# Restarts the daemon with rlimit-nofile=100 so the limits are
+# reachable with a small number of connections:
+#   max_clients = min(4096, 100 * 3/4) = 75
+#   max_uid_clients = 75 / 2 = 37
+test_simple_protocol_limits() {
+    local _i _refused _pid
+    # _saved_rlimit and _pids are intentionally NOT local so that
+    # _simple_protocol_limits_cleanup can access them from the EXIT
+    # trap even if set -e kills the script outside this function.
+    _saved_rlimit=""
+    _pids=()
+
+    _saved_rlimit=$(perl -lne 'print $1 if /^(#?rlimit-nofile=.*)/' "$avahi_daemon_conf")
+    sed -i.bak 's|^#*rlimit-nofile=.*|rlimit-nofile=100|' "$avahi_daemon_conf"
+
+    # Ensure config is restored and flood connections are cleaned up
+    # on any exit, including set -e failures.
+    trap '_simple_protocol_limits_cleanup' EXIT
+
+    if [[ "$WITH_SYSTEMD" == true ]]; then
+        run systemctl restart avahi-daemon
+    elif [[ "$VALGRIND" == true ]]; then
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        valgrind --log-file="$valgrind_log_file" --leak-check=full \
+            --track-origins=yes --track-fds=yes --error-exitcode=1 \
+            --trace-children=yes \
+            -s --suppressions=.github/workflows/avahi-daemon.supp \
+            avahi-daemon -D --debug --no-drop-root --no-proc-title
+    elif [[ "$ASAN_UBSAN" == true ]]; then
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        ASAN_OPTIONS="$ASAN_OPTIONS:log_path=/tmp/asan.avahi-daemon" \
+        UBSAN_OPTIONS="$UBSAN_OPTIONS:log_path=/tmp/ubsan.avahi-daemon" \
+            avahi-daemon -D --debug --no-drop-root
+    else
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        avahi-daemon -D --debug
+    fi
+    # Allow daemon to finish startup and bind the socket
+    sleep 2
+
+    _pid=$(cat "$avahi_daemon_pid_file")
+    kill -0 "$_pid"
+
+    printf "%s\n" "HELP" | socat -t3 - "unix-connect:$avahi_socket,shut-none" \
+        | grep -q "Available commands"
+
+    # --- Per-UID limit ---
+    # Open 40 connections as a non-root user. With max_uid_clients=37,
+    # connections 38+ are refused for that UID.
+    # Root (uid=0) is exempt from per-UID limits, so a privilege drop
+    # is required. runuser is Linux-specific; skip on other platforms.
+    if command -v runuser >/dev/null 2>&1; then
+        # Take a baseline count so we only assert on new refusals
+        # from this flood, not stale entries from prior test runs.
+        local _baseline_uid
+        _baseline_uid=$(_simple_protocol_limits_count "too many uid clients")
+
+        _pids=()
+        for _i in $(seq 1 40); do
+            runuser -u avahi -- \
+                socat -T30 PIPE "unix-connect:$avahi_socket,shut-none" &
+            _pids+=("$!")
+        done
+        # socat connect() is synchronous and the daemon processes
+        # accept() in its event loop immediately; 3s is sufficient.
+        sleep 3
+
+        kill -0 "$_pid"
+
+        _refused=$(( $(_simple_protocol_limits_count "too many uid clients") - _baseline_uid ))
+        if [[ "$_refused" -le 0 ]]; then
+            dump_journal || true
+            exit 1
+        fi
+
+        for _i in "${_pids[@]}"; do
+            kill "$_i" 2>/dev/null || true
+        done
+        _pids=()
+        # Allow the daemon to process disconnections and free slots
+        sleep 2
+
+        printf "%s\n" "HELP" \
+            | socat -t3 - "unix-connect:$avahi_socket,shut-none" \
+            | grep -q "Available commands"
+    fi
+
+    # --- Total client limit ---
+    # Open 80 connections as root. Root bypasses per-UID limits but
+    # the global max_clients=75 still applies.
+    local _baseline_total
+    _baseline_total=$(_simple_protocol_limits_count "too many clients$")
+
+    _pids=()
+    for _i in $(seq 1 80); do
+        socat -T30 PIPE "unix-connect:$avahi_socket,shut-none" &
+        _pids+=("$!")
+    done
+    sleep 3
+
+    kill -0 "$_pid"
+
+    # Verify refusal was logged. The trailing $ anchor distinguishes
+    # "too many clients" (global) from "too many uid clients: N" (per-UID).
+    # On non-systemd BSD, debug messages may not reach syslog depending
+    # on the syslog.conf, so only assert the count on systemd or Linux.
+    _refused=$(( $(_simple_protocol_limits_count "too many clients$") - _baseline_total ))
+    if [[ "$WITH_SYSTEMD" == true || "$OS" == ubuntu ]] && [[ "$_refused" -le 0 ]]; then
+        dump_journal || true
+        exit 1
+    fi
+
+    for _i in "${_pids[@]}"; do
+        kill "$_i" 2>/dev/null || true
+    done
+    _pids=()
+    sleep 2
+
+    # Daemon accepts connections after both floods
+    printf "%s\n" "HELP" | socat -t3 - "unix-connect:$avahi_socket,shut-none" \
+        | grep -q "Available commands"
+
+    # Cleanup runs via the EXIT trap; clear it on success so it
+    # does not interfere with the rest of the script.
+    _simple_protocol_limits_cleanup
+    trap - EXIT
+
+    # Restart daemon with original config for remaining tests
+    if [[ "$WITH_SYSTEMD" == true ]]; then
+        run systemctl restart avahi-daemon
+    elif [[ "$VALGRIND" == true ]]; then
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        valgrind --log-file="$valgrind_log_file" --leak-check=full \
+            --track-origins=yes --track-fds=yes --error-exitcode=1 \
+            --trace-children=yes \
+            -s --suppressions=.github/workflows/avahi-daemon.supp \
+            avahi-daemon -D --debug --no-drop-root --no-proc-title
+    elif [[ "$ASAN_UBSAN" == true ]]; then
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        ASAN_OPTIONS="$ASAN_OPTIONS:log_path=/tmp/asan.avahi-daemon" \
+        UBSAN_OPTIONS="$UBSAN_OPTIONS:log_path=/tmp/ubsan.avahi-daemon" \
+            avahi-daemon -D --debug --no-drop-root
+    else
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        avahi-daemon -D --debug
+    fi
+    sleep 2
+}
+
+# Helpers for test_simple_protocol_limits. Defined at top level
+# because nested functions have no precedent in this file.
+
+_simple_protocol_limits_cleanup() {
+    for _i in "${_pids[@]}"; do
+        kill "$_i" 2>/dev/null || true
+    done
+    _pids=()
+
+    if [[ -n "${_saved_rlimit:-}" ]]; then
+        sed -i.bak "s|^rlimit-nofile=100|$_saved_rlimit|" "$avahi_daemon_conf"
+    else
+        sed -i.bak '/^rlimit-nofile=100/d' "$avahi_daemon_conf"
+    fi
+    rm -f "${avahi_daemon_conf}.bak"
+}
+
+_simple_protocol_limits_count() {
+    local _pattern="$1" _count=0
+
+    if [[ "$WITH_SYSTEMD" == true ]]; then
+        journalctl --sync
+        _count=$(journalctl -b -u avahi-daemon --no-pager \
+            | grep -c "$_pattern") || _count=0
+    elif [[ -f /var/log/syslog ]]; then
+        _count=$(grep -c "$_pattern" /var/log/syslog) || _count=0
+    elif [[ -f /var/log/messages ]]; then
+        _count=$(grep -c "$_pattern" /var/log/messages) || _count=0
+    elif [[ -f /var/adm/messages ]]; then
+        _count=$(grep -c "$_pattern" /var/adm/messages) || _count=0
+    fi
+
+    printf "%d" "$_count"
+}
+
+
+
 install_nss_mdns
 
 run avahi-daemon -h
@@ -312,6 +505,8 @@ if [[ "$WITH_DBUS" == true ]]; then
 fi
 
 check_rlimit_nofile
+
+test_simple_protocol_limits
 
 l=$(hostname | sed 's/\.local$//')
 h="$l.local"

--- a/avahi-daemon/main.c
+++ b/avahi-daemon/main.c
@@ -1187,11 +1187,23 @@ static int run_server(DaemonConfig *c) {
         goto finish;
     }
 
-    /* We accept clients only of 3/4 file descriptors allowed
-     * in this process. Keep extra for UDP sockets. */
-    nofiles = config.rlimit_nofile * 3/4;
-    if (nofiles > MAX_NOFILE_LIMIT)
-        nofiles = MAX_NOFILE_LIMIT;
+    /* Derive the simple protocol client limit from the actual effective
+     * RLIMIT_NOFILE, not the configured value, because setrlimit() may
+     * have failed (hard limit too low) or --no-rlimits may be in use.
+     * Reading the live limit ensures we never try to hold more fds than
+     * the process is actually allowed. */
+    {
+        struct rlimit rl;
+        rlim_t effective_nofile = config.rlimit_nofile;
+
+        if (getrlimit(RLIMIT_NOFILE, &rl) == 0)
+            effective_nofile = rl.rlim_cur;
+
+        if (effective_nofile > MAX_NOFILE_LIMIT)
+            nofiles = MAX_NOFILE_LIMIT;
+        else
+            nofiles = (unsigned)(effective_nofile * 3 / 4);
+    }
     if (simple_protocol_setup(poll_api, nofiles) < 0)
         goto finish;
 

--- a/avahi-daemon/main.c
+++ b/avahi-daemon/main.c
@@ -1201,8 +1201,10 @@ static int run_server(DaemonConfig *c) {
 
         if (effective_nofile > MAX_NOFILE_LIMIT)
             nofiles = MAX_NOFILE_LIMIT;
-        else
+        else if (effective_nofile > 0)
             nofiles = (unsigned)(effective_nofile * 3 / 4);
+        else
+            nofiles = 1;
     }
     if (simple_protocol_setup(poll_api, nofiles) < 0)
         goto finish;

--- a/avahi-daemon/simple-protocol.c
+++ b/avahi-daemon/simple-protocol.c
@@ -574,7 +574,7 @@ static int is_client_allowed(Server *s, int cfd, AvahiCred *cred) {
      * "unknown UID" bucket, which effectively limits them to max_uid_clients
      * instead of max_clients. This is an acceptable tradeoff: returning 0
      * (root) would silently skip per-UID enforcement entirely. */
-    if (uid != 0 && n_clients > s->max_uid_clients) {
+    if (uid != 0 && n_clients >= s->max_uid_clients) {
         /* There are enough clients to reach the limit for one UID.
          * Check this UID does not have too many connections already. */
         Client *c;

--- a/avahi-daemon/simple-protocol.c
+++ b/avahi-daemon/simple-protocol.c
@@ -64,85 +64,99 @@
 
 #define BUFFER_SIZE (20*1024)
 
-#if __linux__
+#ifdef __linux__
 /* Linux specific support, man 7 unix */
 typedef struct ucred AvahiCred;
 
-
 static uid_t credentials_getuid(const AvahiCred *cred) {
-	return cred->uid;
+    return cred->uid;
 }
 
 static gid_t credentials_getgid(const AvahiCred *cred) {
-	return cred->gid;
+    return cred->gid;
 }
 
 static pid_t credentials_getpid(const AvahiCred *cred) {
-	return cred->pid;
+    return cred->pid;
 }
 
 static int credentials_getsockopt(int fd, AvahiCred *cred, socklen_t *len) {
     *len = sizeof(*cred);
-    memset(cred, 0, sizeof(*cred));
-    return getsockopt(fd, SOL_SOCKET, SO_PEERCRED, cred, len);
+    if (getsockopt(fd, SOL_SOCKET, SO_PEERCRED, cred, len) != 0)
+        return -1;
+    if (*len != sizeof(*cred)) {
+        avahi_log_error("credentials_getsockopt: unexpected credential size %u (expected %zu)",
+                        (unsigned)*len, sizeof(*cred));
+        return -1;
+    }
+    return 0;
 }
 
-#  define CRED_FMT     "uid=%lu gid=%lu pid=%lu"
-#  define CRED_VALS(ucred) (long)credentials_getuid(ucred), (long)credentials_getgid(ucred), (long)credentials_getpid(ucred)
+#  define CRED_FMT     "uid=%lu gid=%lu pid=%ld"
+#  define CRED_ARGS(ucred) , (unsigned long)credentials_getuid(ucred), (unsigned long)credentials_getgid(ucred), (long)credentials_getpid(ucred)
 
 #elif defined(HAVE_STRUCT_XUCRED) && defined(XUCRED_VERSION)
 /* FreeBSD support, man 4 unix */
 typedef struct xucred AvahiCred;
 
 static int credentials_version_check(const AvahiCred *cred) {
-	if (cred->cr_version != XUCRED_VERSION) {
-		avahi_log_debug("credentials_version_check: unsupported version %d",
-				cred->cr_version);
-		return 0;
-	}
-	return 1;
+    if (cred->cr_version != XUCRED_VERSION) {
+        avahi_log_debug("credentials_version_check: unsupported version %d",
+                        cred->cr_version);
+        return 0;
+    }
+    return 1;
 }
 
 static uid_t credentials_getuid(const AvahiCred *cred) {
-	if (!credentials_version_check(cred))
-		return 0;
-	return cred->cr_uid;
+    if (!credentials_version_check(cred))
+        return (uid_t)-1;
+    return cred->cr_uid;
 }
 
 static gid_t credentials_getgid(const AvahiCred *cred) {
-	if (!credentials_version_check(cred) || cred->cr_ngroups <= 0)
-		return 0;
-	return cred->cr_groups[0];
+    if (!credentials_version_check(cred) || cred->cr_ngroups <= 0)
+        return 0;
+    return cred->cr_groups[0];
 }
 
 static pid_t credentials_getpid(const AvahiCred *cred) {
-	if (!credentials_version_check(cred))
-		return 0;
-	return cred->cr_pid;
+    if (!credentials_version_check(cred))
+        return 0;
+    return cred->cr_pid;
 }
 
 static int credentials_getsockopt(int fd, AvahiCred *cred, socklen_t *len) {
     *len = sizeof(*cred);
-    memset(cred, 0, sizeof(*cred));
-    return getsockopt(fd, SOL_LOCAL, LOCAL_PEERCRED, cred, len);
+    if (getsockopt(fd, SOL_LOCAL, LOCAL_PEERCRED, cred, len) != 0)
+        return -1;
+    if (*len != sizeof(*cred)) {
+        avahi_log_error("credentials_getsockopt: unexpected credential size %u (expected %zu)",
+                        (unsigned)*len, sizeof(*cred));
+        return -1;
+    }
+    return 0;
 }
 
-#  define CRED_FMT     "uid=%lu gid=%lu pid=%lu"
-#  define CRED_VALS(ucred) (long)credentials_getuid(ucred), (long)credentials_getgid(ucred), (long)credentials_getpid(ucred)
+#  define CRED_FMT     "uid=%lu gid=%lu pid=%ld"
+#  define CRED_ARGS(ucred) , (unsigned long)credentials_getuid(ucred), (unsigned long)credentials_getgid(ucred), (long)credentials_getpid(ucred)
 
 #else
-/* No support */
-#  define CRED_FMT     "%s"
-#  define CRED_VALS(ucred) ucred
+/* No credential retrieval support on this platform */
+#  define CRED_FMT     ""
+#  define CRED_ARGS(ucred)
 typedef unsigned char AvahiCred; /* need known type size. */
 
-static uid_t credentials_getuid(const AvahiCred *cred) {
-	(void)cred; return 0; /* no support for getting remote user. */
+/* Returns (uid_t)-1 to indicate that the UID is unknown, preventing the
+ * unknown-UID from being silently treated as root (uid 0). */
+static uid_t credentials_getuid(AVAHI_GCC_UNUSED const AvahiCred *cred) {
+    return (uid_t)-1;
 }
 
-static int credentials_getsockopt(int fd, AvahiCred *cred, socklen_t *len) {
-	(void)fd; *len = sizeof(*cred); *cred = 0;
-	return 0;
+static int credentials_getsockopt(AVAHI_GCC_UNUSED int fd, AvahiCred *cred, socklen_t *len) {
+    *len = sizeof(*cred);
+    *cred = 0;
+    return 0;
 }
 #endif
 
@@ -212,7 +226,7 @@ static void client_free(Client *c) {
     c->server->poll_api->watch_free(c->watch);
     close(c->fd);
     avahi_log_debug("simple client %d finished: " CRED_FMT,
-                    c->fd, CRED_VALS(&c->credentials));
+                    c->fd CRED_ARGS(&c->credentials));
 
     AVAHI_LLIST_REMOVE(Client, clients, c->server->clients, c);
     avahi_free(c);
@@ -359,10 +373,10 @@ static void dns_server_browser_callback(
 static void log_request(const Client *c, const char *cmd, const char *arg) {
     if (arg != NULL)
         avahi_log_debug(__FILE__": Got %s request for '%s'. " CRED_FMT,
-                        cmd, arg, CRED_VALS(&c->credentials));
+                        cmd, arg CRED_ARGS(&c->credentials));
     else
         avahi_log_debug(__FILE__": Got %s request. " CRED_FMT,
-                        cmd, CRED_VALS(&c->credentials));
+                        cmd CRED_ARGS(&c->credentials));
 }
 
 static void handle_line(Client *c, const char *s) {
@@ -541,36 +555,44 @@ static int is_client_allowed(Server *s, int cfd, AvahiCred *cred) {
 
     n_clients = s->n_clients + 1;
     if (credentials_getsockopt(cfd, cred, &len) != 0) {
-        avahi_log_error("credentials_getsockopt(%d): %s", cfd, strerror(errno));
+        avahi_log_error("Failed to get peer credentials for fd %d: %s", cfd, strerror(errno));
         return 0;
     }
 
     if (n_clients > s->max_clients) {
         avahi_log_debug("simple client %d refused: "CRED_FMT" too many clients",
-                        cfd, CRED_VALS(cred));
+                        cfd CRED_ARGS(cred));
         return 0;
     }
 
     uid = credentials_getuid(cred);
+    /* Per-UID limit applies to all non-root UIDs. (uid_t)-1 means the UID
+     * is unknown (no credential support on this platform); unknown UIDs are
+     * treated as non-root so they cannot bypass the per-UID limit.
+     *
+     * On platforms without credential support, all connections share one
+     * "unknown UID" bucket, which effectively limits them to max_uid_clients
+     * instead of max_clients. This is an acceptable tradeoff: returning 0
+     * (root) would silently skip per-UID enforcement entirely. */
     if (uid != 0 && n_clients > s->max_uid_clients) {
-        // There is enough clients to reach limit for one UID.
-        // Check this UID does not have too many requests already.
+        /* There are enough clients to reach the limit for one UID.
+         * Check this UID does not have too many connections already. */
         Client *c;
         unsigned present = 0;
 
         for (c = s->clients; c; c = c->clients_next) {
             if (credentials_getuid(&c->credentials) == uid) {
                 present++;
-                if (present > s->max_uid_clients) {
+                if (present >= s->max_uid_clients) {
                     avahi_log_debug("simple client %d refused: "CRED_FMT" too many uid clients: %u",
-                                    cfd, CRED_VALS(cred), present);
+                                    cfd CRED_ARGS(cred), present);
                     return 0;
                 }
             }
         }
     }
     avahi_log_debug("simple client %d/%u accepted: "CRED_FMT,
-                    cfd, n_clients, CRED_VALS(cred));
+                    cfd, n_clients CRED_ARGS(cred));
     return 1;
 }
 
@@ -585,7 +607,7 @@ static void server_work(AVAHI_GCC_UNUSED AvahiWatch *watch, int fd, AvahiWatchEv
         if ((cfd = accept(fd, NULL, NULL)) < 0) {
             if (errno != EMFILE && errno != ENFILE)
                 avahi_log_error(__FILE__" accept(): %s", strerror(errno));
-            else // Avoid client ability to flood log with too many requests
+            else /* Avoid giving clients the ability to flood the log with too many requests */
                 avahi_log_debug(__FILE__" accept(): %s", strerror(errno));
         } else {
             AvahiCred cred;

--- a/avahi-daemon/simple-protocol.h
+++ b/avahi-daemon/simple-protocol.h
@@ -22,7 +22,10 @@
 
 #include <avahi-common/watch.h>
 
-int simple_protocol_setup(const AvahiPoll *poll_api);
+/* max_clients is number of concurrent simple mdns clients allowed.
+ * When limit is reached, new clients are immediately closed.
+ * Per UID limit is derived from this number. */
+int simple_protocol_setup(const AvahiPoll *poll_api, unsigned max_clients);
 void simple_protocol_shutdown(void);
 void simple_protocol_restart_queries(void);
 

--- a/configure.ac
+++ b/configure.ac
@@ -222,6 +222,21 @@ if test $avahi_cv_has_struct_lifconf = yes; then
 fi
 
 #
+# Check for xucred struct; only present on FreeBSD
+#
+AC_MSG_CHECKING(for struct xucred)
+AC_CACHE_VAL(avahi_cv_has_struct_xucred,
+[AC_TRY_COMPILE(
+[#include <sys/socket.h>
+#include <sys/ucred.h>
+],[sizeof (struct xucred);],
+avahi_cv_has_struct_xucred=yes,avahi_cv_has_struct_xucred=no)])
+AC_MSG_RESULT($avahi_cv_has_struct_xucred)
+if test $avahi_cv_has_struct_xucred = yes; then
+    AC_DEFINE(HAVE_STRUCT_XUCRED,1,[Define if there is a struct xucred.])
+fi
+
+#
 # Check for struct ip_mreqn
 #
 AC_MSG_CHECKING(for struct ip_mreqn)


### PR DESCRIPTION
Picking up where #808 left off. First commit is @pemensik's connection limit fix (squashed from #808), second addresses @evverx's review and adds smoke tests, third fixes CI issues.


Commit 1 adds per-UID and global client limits to the simple protocol, derived from `RLIMIT_NOFILE`. Commit 2 fixes the review feedback from #808: unknown UID returns `(uid_t)-1` not `0`, validates `getsockopt` length, fixes format string UB on no-credential platforms, fixes the off-by-one in the per-UID check, and cleans up style. It also adds smoke tests that set `rlimit-nofile=100` (so max_clients=75, per_uid=37) and flood the socket to verify refusals are logged.

Commit 3 fixes CI: under Valgrind, `setrlimit()` is intercepted, so the test sets `ulimit -n 100` before launching Valgrind. On systemd, a transient `LimitNOFILE=100` drop-in is needed since the unit's limit overrides the daemon config. Also restarts `avahi-dnsconfd` after each daemon kill in the test (it dies when the daemon does), and fixes an off-by-one in the per-UID fast-path guard and a `max_clients=0` edge case.

**Limitations**

- `cr_pid` may need `AC_CHECK_MEMBERS` guard for FreeBSD < 13.2
- Per-UID enforcement requires credential support; without it, only the global limit applies
- Per-UID smoke test needs `runuser` (Linux only)