### PR TITLE
ini-file-parser: raise line buffer from 1024 to 2048 bytes

### DIFF
--- a/avahi-daemon/ini-file-parser.c
+++ b/avahi-daemon/ini-file-parser.c
@@ -50,7 +50,7 @@ AvahiIniFile* avahi_ini_file_load(const char *fname) {
 
     line = 0;
     while (!feof(fo)) {
-        char ln[1024], *s, *e;
+        char ln[2048], *s, *e;
         AvahiIniFilePair *pair;
 
         if (!(fgets(ln, sizeof(ln), fo)))


### PR DESCRIPTION
The ini parser reads each line of avahi-daemon.conf into a fixed 1024-byte stack buffer via fgets(). For list-valued keys such as allow-interfaces= this limits the number of interface names that can be listed on a single config line. With a maximum interface name length of 15 characters plus a comma separator (16 bytes per entry), a 1024-byte buffer supports only ~64 interfaces.

Raise the buffer to 2048 bytes to support up to 128 interfaces in a single list-valued key.

The buffer lives on the stack of avahi_ini_file_load(), which only runs once at daemon startup from a shallow call site, so the extra bytes of stack usage are inconsequential.

No functional change for configurations that already fit in 1024 bytes.