### PR TITLE
fix: replace __FUNCTION__ with __func__ in AVAHI_WARN_UNSUPPORTED

### DIFF
--- a/avahi-compat-libdns_sd/warn.h
+++ b/avahi-compat-libdns_sd/warn.h
@@ -30,7 +30,7 @@ void avahi_warn_linkage(void);
 void avahi_warn(const char *fmt, ...);
 
 #define AVAHI_WARN_LINKAGE do { avahi_warn_linkage(); } while(0)
-#define AVAHI_WARN_UNSUPPORTED do { avahi_warn_linkage(); avahi_warn_unsupported(__FUNCTION__); } while(0)
+#define AVAHI_WARN_UNSUPPORTED do { avahi_warn_linkage(); avahi_warn_unsupported(__func__); } while(0)
 #define AVAHI_WARN_UNSUPPORTED_ABORT do { AVAHI_WARN_UNSUPPORTED; abort(); } while(0)
 
 #endif


### PR DESCRIPTION
ISO C does not support the __FUNCTION__ predefined identifier; it is a GCC extension. Replace it with __func__, which is standardised in C99 (ISO/IEC 9899:1999 §6.4.2.2), to silence -Wpedantic warnings.

Fixes warning in warn.h:33 surfaced via compat.c