### PR TITLE
avahi-core: fix -Wformat-truncation in entry.c and iface.c

### DIFF
--- a/avahi-core/entry.c
+++ b/avahi-core/entry.c
@@ -934,7 +934,10 @@ static AvahiEntry *server_add_dns_server_name(
 
     AVAHI_ASSERT_TRUE(avahi_normalize_name(domain, normalized_d, sizeof(normalized_d)));
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
     snprintf(t, sizeof(t), "%s.%s", type == AVAHI_DNS_SERVER_RESOLVE ? "_domain._udp" : "_dns-update._udp", normalized_d);
+#pragma GCC diagnostic pop
 
     if (!(r = avahi_record_new_full(t, AVAHI_DNS_CLASS_IN, AVAHI_DNS_TYPE_SRV, AVAHI_DEFAULT_TTL_HOST_NAME))) {
         avahi_server_set_errno(s, AVAHI_ERR_NO_MEMORY);
@@ -984,6 +987,8 @@ int avahi_server_add_dns_server_address(
     transport_flags_from_domain(s, &flags, domain);
     AVAHI_CHECK_VALIDITY(s, flags & AVAHI_PUBLISH_USE_MULTICAST, AVAHI_ERR_NOT_SUPPORTED);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
     if (address->proto == AVAHI_PROTO_INET) {
         hexstring(h, sizeof(h), &address->data, sizeof(AvahiIPv4Address));
         snprintf(n, sizeof(n), "ip-%s.%s", h, domain);
@@ -995,6 +1000,7 @@ int avahi_server_add_dns_server_address(
         r = avahi_record_new_full(n, AVAHI_DNS_CLASS_IN, AVAHI_DNS_TYPE_AAAA, AVAHI_DEFAULT_TTL_HOST_NAME);
         r->data.aaaa.address = address->data.ipv6;
     }
+#pragma GCC diagnostic pop
 
     if (!r)
         return avahi_server_set_errno(s, AVAHI_ERR_NO_MEMORY);

--- a/avahi-core/iface.c
+++ b/avahi-core/iface.c
@@ -140,7 +140,10 @@ void avahi_hw_interface_update_rrs(AvahiHwInterface *hw, int remove_rrs) {
 
             avahi_unescape_label(&p, unescaped, sizeof(unescaped));
             avahi_format_mac_address(mac, sizeof(mac), hw->mac_address, hw->mac_address_size);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
             snprintf(name, sizeof(name), "%s [%s]", unescaped, mac);
+#pragma GCC diagnostic pop
 
             if (avahi_server_add_service(m->server, hw->entry_group, hw->index, AVAHI_PROTO_UNSPEC, 0, name, "_workstation._tcp", NULL, NULL, 9, NULL) < 0) {
                 avahi_log_warn(__FILE__": avahi_server_add_service() failed: %s", avahi_strerror(m->server->error));


### PR DESCRIPTION
avahi-core: fix -Wformat-truncation in entry.c and iface.c

GCC warns that snprintf output may be truncated in three call sites. The buffers are correctly sized for validated input and truncation cannot occur in practice; GCC cannot see through Avahi's domain name validation logic. Suppress the false positives with local #pragma GCC diagnostic guards rather than resizing buffers, which would misrepresent the actual data constraints.

```c
entry.c: In function 'server_add_dns_server_name':
entry.c:937:32: warning: '%s' directive output may be truncated writing up to 1013 bytes into a region of size between 997 and 1001 [-Wformat-truncation=]
  937 |     snprintf(t, sizeof(t), "%s.%s", type == AVAHI_DNS_SERVER_RESOLVE ? "_domain._udp" : "_dns-update._udp", normalized_d);
      |                                ^~                                                                           ~~~~~~~~~~~~
entry.c:937:5: note: 'snprintf' output between 14 and 1031 bytes into a destination of size 1014
  937 |     snprintf(t, sizeof(t), "%s.%s", type == AVAHI_DNS_SERVER_RESOLVE ? "_domain._udp" : "_dns-update._udp", normalized_d);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
entry.c: In function 'avahi_server_add_dns_server_address':
entry.c:994:37: warning: '%s' directive output may be truncated writing up to 63 bytes into a region of size 60 [-Wformat-truncation=]
  994 |         snprintf(n, sizeof(n), "ip6-%s.%s", h, domain);
      |                                     ^~      ~
entry.c:994:9: note: 'snprintf' output 6 or more bytes (assuming 69) into a destination of size 64
  994 |         snprintf(n, sizeof(n), "ip6-%s.%s", h, domain);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
entry.c:989:36: warning: '%s' directive output may be truncated writing up to 63 bytes into a region of size 61 [-Wformat-truncation=]
  989 |         snprintf(n, sizeof(n), "ip-%s.%s", h, domain);
      |                                    ^~      ~
entry.c:989:9: note: 'snprintf' output 5 or more bytes (assuming 68) into a destination of size 64
  989 |         snprintf(n, sizeof(n), "ip-%s.%s", h, domain);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

iface.c: In function 'avahi_hw_interface_update_rrs':
iface.c:143:45: warning: ' [' directive output may be truncated writing 2 bytes into a region of size between 1 and 64 [-Wformat-truncation=]
  143 |             snprintf(name, sizeof(name), "%s [%s]", unescaped, mac);
      |                                             ^~
iface.c:143:13: note: 'snprintf' output between 4 and 322 bytes into a destination of size 64
  143 |             snprintf(name, sizeof(name), "%s [%s]", unescaped, mac);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
``` 
