### PR TITLE
ci: roll out NDEBUG job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,10 @@ jobs:
             env: { CC: "clang", ASAN_UBSAN: "true", ADDITIONAL_AUTOGEN_ARGS: "--disable-dbus --disable-libsystemd --without-systemdsystemunitdir" }
           - runner: ubuntu-24.04
             env: { CC: "gcc", VALGRIND: "true", ADDITIONAL_AUTOGEN_ARGS: "--disable-dbus --disable-libsystemd --without-systemdsystemunitdir" }
+          - runner: ubuntu-24.04
+            env: { CC: "gcc", VALGRIND: "true", CFLAGS: "-g -O0 -DNDEBUG" }
+          - runner: ubuntu-24.04
+            env: { CC: "clang", ASAN_UBSAN: "true", CFLAGS: "-g -O0 -DNDEBUG" }
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout

--- a/avahi-common/strlst-test.c
+++ b/avahi-common/strlst-test.c
@@ -78,7 +78,8 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
 
     printf("\n");
 
-    assert(avahi_string_list_parse(data, size, &b) == 0);
+    r = avahi_string_list_parse(data, size, &b);
+    assert(r == 0);
 
     printf("equal: %i\n", avahi_string_list_equal(a, b));
 
@@ -128,7 +129,8 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     assert(size == 1);
     assert(size == n);
 
-    assert(avahi_string_list_parse(data, size, &a) == 0);
+    r = avahi_string_list_parse(data, size, &a);
+    assert(r == 0);
     assert(!a);
 
     return 0;


### PR DESCRIPTION
to make sure that use case isn't completely broken and call `avahi_string_list_parse` outside of `assert` to get `strlst-test` to pass under Valgrind and ASan. Without that it fails with
```sh
==26513== Conditional jump or move depends on uninitialised value(s)
==26513==    at 0x109A67: avahi_string_list_equal (strlst.c:302)
==26513==    by 0x10AEA1: main (strlst-test.c:83)
==26513==  Uninitialised value was created by a stack allocation
==26513==    at 0x10AABC: main (strlst-test.c:31)
==26513== 
==26513== Use of uninitialised value of size 8
==26513==    at 0x109A7C: avahi_string_list_equal (strlst.c:305)
==26513==    by 0x10AEA1: main (strlst-test.c:83)
==26513==  Uninitialised value was created by a stack allocation
==26513==    at 0x10AABC: main (strlst-test.c:31)
==26513== 
==26513== Invalid read of size 8
==26513==    at 0x109A7C: avahi_string_list_equal (strlst.c:305)
==26513==    by 0x10AEA1: main (strlst-test.c:83)
==26513==  Address 0x1e0000000e is not stack'd, malloc'd or (recently) free'd
==26513== 
==26513== 
==26513== Process terminating with default action of signal 11 (SIGSEGV)
```
```sh
AddressSanitizer:DEADLYSIGNAL
=================================================================
==25435==ERROR: AddressSanitizer: stack-overflow on address 0x7fffb4b96000 (pc 0x558cc9718209 bp 0x7fffb4b93b90 sp 0x7fffb4b938c0 T0)
    #0 0x558cc9718209 in avahi_string_list_to_string /home/runner/work/avahi/avahi/avahi-common/strlst.c:173:21
    #1 0x558cc971e155 in main /home/runner/work/avahi/avahi/avahi-common/strlst-test.c:85:9
    #2 0x7f7fd882a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #3 0x7f7fd882a28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #4 0x558cc963e344 in _start (/home/runner/work/avahi/avahi/avahi-common/strlst-test+0x2e344) (BuildId: ad1c456aeeea3678d3125953b3a2d9299ed8e42b)

SUMMARY: AddressSanitizer: stack-overflow /home/runner/work/avahi/avahi/avahi-common/strlst.c:173:21 in avahi_string_list_to_string
==25435==ABORTING
```