### PR TITLE
avahi-common: fix -Wunused-value warnings in i18n.h no-op macros

### DIFF
--- a/avahi-common/i18n.h
+++ b/avahi-common/i18n.h
@@ -43,8 +43,8 @@
 #define gettext(String) (String)
 #define dgettext(Domain,String) (String)
 #define dcgettext(Domain,String,Type) (String)
-#define bindtextdomain(Domain,Directory) (Domain)
-#define bind_textdomain_codeset(Domain,Codeset) (Codeset)
+#define bindtextdomain(Domain,Directory) ((void)(Domain))
+#define bind_textdomain_codeset(Domain,Codeset) ((void)(Codeset))
 
 #endif /* ENABLE_NLS */
 


### PR DESCRIPTION
bindtextdomain and bind_textdomain_codeset were defined to return their first argument, causing -Wunused-value warnings when called as statements without NLS. Cast to void to suppress the warnings.

(Split out of #900)

```c

In file included from i18n.c:24:
i18n.c: In function 'avahi_init_i18n':
i18n.h:46:42: warning: statement with no effect [-Wunused-value]
   46 | #define bindtextdomain(Domain,Directory) (Domain)
      |                                          ^
i18n.c:34:9: note: in expansion of macro 'bindtextdomain'
   34 |         bindtextdomain(GETTEXT_PACKAGE, AVAHI_LOCALEDIR);
      |         ^~~~~~~~~~~~~~
i18n.h:47:49: warning: statement with no effect [-Wunused-value]
   47 | #define bind_textdomain_codeset(Domain,Codeset) (Codeset)
      |                                                 ^
i18n.c:35:9: note: in expansion of macro 'bind_textdomain_codeset'
   35 |         bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
      |         ^~~~~~~~~~~~~~~~~~~~~~~

``` 