### PR TITLE
avahi: fix -Wunused-but-set-variable and -Wunused-variable warnings

### DIFF
--- a/avahi-common/domain.c
+++ b/avahi-common/domain.c
@@ -239,8 +239,10 @@ int avahi_domain_equal(const char *a, const char *b) {
 
         r = avahi_unescape_label(&a, ca, sizeof(ca));
         assert(r);
+        (void)r;
         r = avahi_unescape_label(&b, cb, sizeof(cb));
         assert(r);
+        (void)r;
 
         if (strcasecmp(ca, cb))
             return 0;
@@ -430,6 +432,7 @@ unsigned avahi_domain_hash(const char *s) {
 
         r = avahi_unescape_label(&s, c, sizeof(c));
         assert(r);
+        (void)r;
 
         for (p = c; *p; p++)
             hash = 31 * hash + tolower(*p);
@@ -463,6 +466,7 @@ int avahi_service_name_join(char *p, size_t size, const char *name, const char *
         char *e = escaped_name, *r;
         r = avahi_escape_label(name, strlen(name), &e, &l);
         assert(r);
+        (void)r;
     }
 
     if (!(avahi_normalize_name(type, normalized_type, sizeof(normalized_type))))

--- a/avahi-compat-libdns_sd/compat.c
+++ b/avahi-compat-libdns_sd/compat.c
@@ -94,7 +94,7 @@ struct _DNSServiceRef_t {
     AvahiEntryGroup *entry_group;
 };
 
-#define ASSERT_SUCCESS(r) { int __ret = (r); assert(__ret == 0); }
+#define ASSERT_SUCCESS(r) { int __ret = (r); assert(__ret == 0); (void)__ret; }
 
 static DNSServiceErrorType map_error(int error) {
     switch (error) {
@@ -707,6 +707,7 @@ static void service_resolver_callback(
 
             ret = avahi_service_name_join(full_name, sizeof(full_name), name, type, domain);
             assert(ret == AVAHI_OK);
+            (void)ret;
 
             strcat(full_name, ".");
 

--- a/avahi-core/cache.c
+++ b/avahi-core/cache.c
@@ -380,10 +380,9 @@ struct dump_data {
 
 static void dump_callback(void* key, void* data, void* userdata) {
     AvahiCacheEntry *e = data;
-    AvahiKey *k = key;
     struct dump_data *dump_data = userdata;
 
-    assert(k);
+    assert(key);
     assert(e);
     assert(data);
 

--- a/avahi-core/domain-util.c
+++ b/avahi-core/domain-util.c
@@ -176,8 +176,10 @@ int avahi_binary_domain_cmp(const char *a, const char *b) {
 
         p = avahi_unescape_label(&a, ca, sizeof(ca));
         assert(p);
+        (void)p;
         p = avahi_unescape_label(&b, cb, sizeof(cb));
         assert(p);
+        (void)p;
 
         if ((r = strcmp(ca, cb)))
             return r;
@@ -202,6 +204,7 @@ int avahi_domain_ends_with(const char *domain, const char *suffix) {
 
         r = avahi_unescape_label(&domain, dummy, sizeof(dummy));
         assert(r);
+        (void)r;
     }
 }
 

--- a/avahi-core/iface.c
+++ b/avahi-core/iface.c
@@ -554,7 +554,7 @@ AvahiHwInterface* avahi_interface_monitor_get_hw_interface(AvahiInterfaceMonitor
     return avahi_hashmap_lookup(m->hashmap, &idx);
 }
 
-AvahiInterfaceAddress* avahi_interface_monitor_get_address(AvahiInterfaceMonitor *m, AvahiInterface *i, const AvahiAddress *raddr) {
+AvahiInterfaceAddress* avahi_interface_monitor_get_address(AVAHI_GCC_UNUSED AvahiInterfaceMonitor *m, AvahiInterface *i, const AvahiAddress *raddr) {
     AvahiInterfaceAddress *ia;
 
     assert(m);

--- a/avahi-core/internal.h
+++ b/avahi-core/internal.h
@@ -217,6 +217,7 @@ int avahi_server_add_ptr(
 #define AVAHI_ASSERT_TRUE(expression) { \
     int __tmp = !!(expression); \
     assert(__tmp); \
+    (void)__tmp; \
 }
 
 #define AVAHI_ASSERT_SUCCESS(expression) { \

--- a/avahi-core/probe-sched.c
+++ b/avahi-core/probe-sched.c
@@ -188,6 +188,7 @@ static int packet_add_probe_query(AvahiProbeScheduler *s, AvahiDnsPacket *p, Ava
 
     b = !!avahi_dns_packet_append_key(p, k, 0);
     assert(b);
+    (void)b;
 
     /* reserve size for record data */
     avahi_dns_packet_reserve_size(p, avahi_record_get_estimate_size(pj->record));

--- a/avahi-core/query-sched.c
+++ b/avahi-core/query-sched.c
@@ -293,6 +293,7 @@ static void elapse_callback(AVAHI_GCC_UNUSED AvahiTimeEvent *e, void* data) {
 
     b = packet_add_query_job(s, p, qj);
     assert(b); /* An query must always fit in */
+    (void)b;
     n = 1;
 
     /* Try to fill up packet with more queries, if available */

--- a/avahi-core/socket.c
+++ b/avahi-core/socket.c
@@ -785,6 +785,7 @@ AvahiDnsPacket *avahi_recv_dns_packet_ipv4(
     }
 
     assert(found_addr);
+    (void)found_addr;
 
     return p;
 
@@ -908,6 +909,8 @@ AvahiDnsPacket *avahi_recv_dns_packet_ipv6(
 
     assert(found_iface);
     assert(found_ttl);
+    (void)found_iface;
+    (void)found_ttl;
 
     return p;
 

--- a/avahi-core/wide-area.c
+++ b/avahi-core/wide-area.c
@@ -298,6 +298,7 @@ AvahiWideAreaLookup *avahi_wide_area_lookup_new(
 
     p = avahi_dns_packet_append_key(l->packet, key, 0);
     assert(p);
+    (void)p;
 
     avahi_dns_packet_set_field(l->packet, AVAHI_DNS_FIELD_QDCOUNT, 1);
 

--- a/avahi-utils/sigint.c
+++ b/avahi-utils/sigint.c
@@ -74,6 +74,7 @@ static void watch_callback(AvahiWatch *w, int fd, AvahiWatchEvent event, AVAHI_G
 
     l = read(fd, &s, sizeof(s));
     assert(l == sizeof(s));
+    (void)l;
 
     fprintf(stderr, "Got %s, quitting.\n", s == SIGINT ? "SIGINT" : "SIGTERM");
     avahi_simple_poll_quit(simple_poll);


### PR DESCRIPTION
All affected variables are only consumed by assert(), which is compiled away when NDEBUG is set, leaving them set but never read. Add (void) casts after each assert to make the debug-only intent explicit.

Fix the ASSERT_SUCCESS macro in compat.c and the AVAHI_ASSERT_TRUE macro in internal.h the same way, covering all their call sites in one change.

Remove the redundant k alias in cache.c dump_callback and assert the original key parameter directly.

avahi-core/iface.c: mark m unused in avahi_interface_monitor_get_address, only consumed by assert().

(Split out of #900)

```c

domain.c: In function 'avahi_domain_equal':
domain.c:238:57: warning: variable 'r' set but not used [-Wunused-but-set-variable=]
  238 |         char ca[AVAHI_LABEL_MAX], cb[AVAHI_LABEL_MAX], *r;
      |                                                         ^
domain.c: In function 'avahi_domain_hash':
domain.c:429:39: warning: variable 'r' set but not used [-Wunused-but-set-variable=]
  429 |         char c[AVAHI_LABEL_MAX], *p, *r;
      |                                       ^
domain.c: In function 'avahi_service_name_join':
domain.c:463:34: warning: variable 'r' set but not used [-Wunused-but-set-variable=]
  463 |         char *e = escaped_name, *r;
      |                                  ^
probe-sched.c: In function 'packet_add_probe_query':
probe-sched.c:168:9: warning: variable 'b' set but not used [-Wunused-but-set-variable=]
  168 |     int b;
      |         ^
cache.c: In function 'dump_callback':
cache.c:406:15: warning: unused variable 'k' [-Wunused-variable]
  406 |     AvahiKey *k = key;
      |               ^
query-sched.c: In function 'elapse_callback':
query-sched.c:278:9: warning: variable 'b' set but not used [-Wunused-but-set-variable=]
  278 |     int b;
      |         ^
socket.c: In function 'avahi_recv_dns_packet_ipv4':
socket.c:651:9: warning: variable 'found_addr' set but not used [-Wunused-but-set-variable=]
  651 |     int found_addr = 0;
      |         ^~~~~~~~~~
socket.c: In function 'avahi_recv_dns_packet_ipv6':
socket.c:813:24: warning: variable 'found_iface' set but not used [-Wunused-but-set-variable=]
  813 |     int found_ttl = 0, found_iface = 0;
      |                        ^~~~~~~~~~~
socket.c:813:9: warning: variable 'found_ttl' set but not used [-Wunused-but-set-variable=]
  813 |     int found_ttl = 0, found_iface = 0;
      |         ^~~~~~~~~
In file included from entry.c:43:
entry.c: In function 'avahi_server_add_address':
internal.h:218:9: warning: unused variable '__tmp' [-Wunused-variable]
  218 |     int __tmp = !!(expression); \
      |         ^~~~~
entry.c:466:9: note: in expansion of macro 'AVAHI_ASSERT_TRUE'
  466 |         AVAHI_ASSERT_TRUE(avahi_normalize_name(name, n, sizeof(n)));
      |         ^~~~~~~~~~~~~~~~~
entry.c:935:5: note: in expansion of macro 'AVAHI_ASSERT_TRUE'
  935 |     AVAHI_ASSERT_TRUE(avahi_normalize_name(domain, normalized_d, sizeof(normalized_d)));
      |     ^~~~~~~~~~~~~~~~~
domain-util.c: In function 'avahi_binary_domain_cmp':
domain-util.c:174:57: warning: variable 'p' set but not used [-Wunused-but-set-variable=]
  174 |         char ca[AVAHI_LABEL_MAX], cb[AVAHI_LABEL_MAX], *p;
      |                                                         ^
domain-util.c: In function 'avahi_domain_ends_with':
domain-util.c:195:39: warning: variable 'r' set but not used [-Wunused-but-set-variable=]
  195 |         char dummy[AVAHI_LABEL_MAX], *r;
      |                                       ^
wide-area.c: In function 'avahi_wide_area_lookup_new':
wide-area.c:270:14: warning: variable 'p' set but not used [-Wunused-but-set-variable=]
  270 |     uint8_t *p;
      |              ^
sigint.c: In function 'watch_callback':
sigint.c:69:13: warning: variable 'l' set but not used [-Wunused-but-set-variable=]
   69 |     ssize_t l;
      |             ^
compat.c: In function 'poll_func':
compat.c:97:33: warning: unused variable '__ret' [-Wunused-variable]
   97 | #define ASSERT_SUCCESS(r) { int __ret = (r); assert(__ret == 0); }
      |                                 ^~~~~
compat.c:294:5: note: in expansion of macro 'ASSERT_SUCCESS'
  294 |     ASSERT_SUCCESS(pthread_mutex_unlock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c:300:5: note: in expansion of macro 'ASSERT_SUCCESS'
  300 |     ASSERT_SUCCESS(pthread_mutex_lock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c: In function 'thread_func':
compat.c:328:17: note: in expansion of macro 'ASSERT_SUCCESS'
  328 |                 ASSERT_SUCCESS(pthread_mutex_lock(&sdref->mutex));
      |                 ^~~~~~~~~~~~~~
compat.c:344:17: note: in expansion of macro 'ASSERT_SUCCESS'
  344 |                 ASSERT_SUCCESS(pthread_mutex_unlock(&sdref->mutex));
      |                 ^~~~~~~~~~~~~~
compat.c: In function 'sdref_new':
compat.c:387:5: note: in expansion of macro 'ASSERT_SUCCESS'
  387 |     ASSERT_SUCCESS(pthread_mutexattr_init(&mutex_attr));
      |     ^~~~~~~~~~~~~~
compat.c:389:5: note: in expansion of macro 'ASSERT_SUCCESS'
  389 |     ASSERT_SUCCESS(pthread_mutex_init(&sdref->mutex, &mutex_attr));
      |     ^~~~~~~~~~~~~~
compat.c: In function 'sdref_free':
compat.c:425:9: note: in expansion of macro 'ASSERT_SUCCESS'
  425 |         ASSERT_SUCCESS(write_command(sdref->main_fd, COMMAND_QUIT));
      |         ^~~~~~~~~~~~~~
compat.c:427:9: note: in expansion of macro 'ASSERT_SUCCESS'
  427 |         ASSERT_SUCCESS(pthread_join(sdref->thread, NULL));
      |         ^~~~~~~~~~~~~~
compat.c:442:5: note: in expansion of macro 'ASSERT_SUCCESS'
  442 |     ASSERT_SUCCESS(pthread_mutex_destroy(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c: In function 'DNSServiceProcessResult':
compat.c:491:5: note: in expansion of macro 'ASSERT_SUCCESS'
  491 |     ASSERT_SUCCESS(pthread_mutex_lock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c:516:5: note: in expansion of macro 'ASSERT_SUCCESS'
  516 |     ASSERT_SUCCESS(pthread_mutex_unlock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
In file included from compat.c:47:
compat.c: In function 'DNSServiceBrowse':
compat.c:644:5: note: in expansion of macro 'ASSERT_SUCCESS'
  644 |     ASSERT_SUCCESS(pthread_mutex_lock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c:663:5: note: in expansion of macro 'ASSERT_SUCCESS'
  663 |     ASSERT_SUCCESS(pthread_mutex_unlock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c: In function 'service_resolver_callback':
compat.c:699:17: warning: variable 'ret' set but not used [-Wunused-but-set-variable=]
  699 |             int ret;
      |                 ^~~
compat.c: In function 'DNSServiceResolve':
compat.c:757:5: note: in expansion of macro 'ASSERT_SUCCESS'
  757 |     ASSERT_SUCCESS(pthread_mutex_lock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c:777:5: note: in expansion of macro 'ASSERT_SUCCESS'
  777 |     ASSERT_SUCCESS(pthread_mutex_unlock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c: In function 'DNSServiceEnumerateDomains':
compat.c:869:5: note: in expansion of macro 'ASSERT_SUCCESS'
  869 |     ASSERT_SUCCESS(pthread_mutex_lock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c:890:5: note: in expansion of macro 'ASSERT_SUCCESS'
  890 |     ASSERT_SUCCESS(pthread_mutex_unlock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c: In function 'DNSServiceRegister':
compat.c:1147:5: note: in expansion of macro 'ASSERT_SUCCESS'
 1147 |     ASSERT_SUCCESS(pthread_mutex_lock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c:1202:5: note: in expansion of macro 'ASSERT_SUCCESS'
 1202 |     ASSERT_SUCCESS(pthread_mutex_unlock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c: In function 'DNSServiceUpdateRecord':
compat.c:1235:5: note: in expansion of macro 'ASSERT_SUCCESS'
 1235 |     ASSERT_SUCCESS(pthread_mutex_lock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c:1267:5: note: in expansion of macro 'ASSERT_SUCCESS'
 1267 |     ASSERT_SUCCESS(pthread_mutex_unlock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c: In function 'DNSServiceQueryRecord':
compat.c:1347:5: note: in expansion of macro 'ASSERT_SUCCESS'
 1347 |     ASSERT_SUCCESS(pthread_mutex_lock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~
compat.c:1366:5: note: in expansion of macro 'ASSERT_SUCCESS'
 1366 |     ASSERT_SUCCESS(pthread_mutex_unlock(&sdref->mutex));
      |     ^~~~~~~~~~~~~~

``` 

```c

iface.c: In function 'avahi_interface_monitor_get_address':
iface.c:557:83: warning: unused parameter 'm' [-Wunused-parameter]
  557 | AvahiInterfaceAddress* avahi_interface_monitor_get_address(AvahiInterfaceMonitor *m, AvahiInterface *i, const AvahiAddress *raddr) {
      |                                                            ~~~~~~~~~~~~~~~~~~~~~~~^

``` 