### PR TITLE
avahi-daemon: fix -Wmaybe-uninitialized warning in static-services.c

### DIFF
--- a/avahi-daemon/static-services.c
+++ b/avahi-daemon/static-services.c
@@ -622,7 +622,7 @@ static void XMLCALL xml_end(void *data, AVAHI_GCC_UNUSED const char *el) {
             assert(u->service);
             if (u->txt_key != NULL) {
                 size_t key_len = strlen(u->txt_key);
-                uint8_t *value_buf;
+                uint8_t *value_buf = NULL;
                 uint8_t *free_value_buf = NULL;
                 size_t value_buf_len = 0;
 


### PR DESCRIPTION
Initialize value_buf to NULL to silence GCC's -Wmaybe-uninitialized warning. The warning is a false positive since all valid txt_type branches assign value_buf before use, but GCC cannot see through assert(0) in the default case when NDEBUG is set.

(Split of of #900)

```c

In function 'xml_end',
    inlined from 'xml_end' at static-services.c:568:21:
static-services.c:659:17: warning: 'value_buf' may be used uninitialized [-Wmaybe-uninitialized]
  659 |                 memcpy(u->service->txt_records->text + key_len + 1, value_buf, value_buf_len);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
static-services.c: In function 'xml_end':
static-services.c:625:26: note: 'value_buf' was declared here
  625 |                 uint8_t *value_buf;
      |                          ^~~~~~~~~

``` 