### PR TITLE
ci: pass -ftrivial-auto-var-init=pattern in NDEBUG ASan/UBSan job explicitly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           - runner: ubuntu-24.04
             env: { CC: "gcc", VALGRIND: "true", CFLAGS: "-g -O0 -DNDEBUG" }
           - runner: ubuntu-24.04
-            env: { CC: "clang", ASAN_UBSAN: "true", CFLAGS: "-g -O0 -DNDEBUG" }
+            env: { CC: "clang", ASAN_UBSAN: "true", CFLAGS: "-g -O0 -DNDEBUG -ftrivial-auto-var-init=pattern" }
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout

--- a/avahi-core/dns-test.c
+++ b/avahi-core/dns-test.c
@@ -44,29 +44,38 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     uint8_t rdata[AVAHI_DNS_RDATA_MAX];
     size_t l;
     int res;
+    uint8_t *resp;
 
     p = avahi_dns_packet_new(0);
 
-    assert(avahi_dns_packet_append_name(p, a = "Ahello.hello.hello.de."));
-    assert(avahi_dns_packet_append_name(p, b = "Bthis is a test.hello.de."));
-    assert(avahi_dns_packet_append_name(p, c = "Cthis\\.is\\.a\\.test\\.with\\.dots.hello.de."));
-    assert(avahi_dns_packet_append_name(p, d = "Dthis\\\\is another test.hello.de."));
+    resp = avahi_dns_packet_append_name(p, a = "Ahello.hello.hello.de.");
+    assert(resp);
+    resp = avahi_dns_packet_append_name(p, b = "Bthis is a test.hello.de.");
+    assert(resp);
+    resp = avahi_dns_packet_append_name(p, c = "Cthis\\.is\\.a\\.test\\.with\\.dots.hello.de.");
+    assert(resp);
+    resp = avahi_dns_packet_append_name(p, d = "Dthis\\\\is another test.hello.de.");
+    assert(resp);
 
     avahi_hexdump(AVAHI_DNS_PACKET_DATA(p), p->size);
 
-    assert(avahi_dns_packet_consume_name(p, t, sizeof(t)) == 0);
+    res = avahi_dns_packet_consume_name(p, t, sizeof(t));
+    assert(res == 0);
     avahi_log_debug(">%s<", t);
     assert(avahi_domain_equal(a, t));
 
-    assert(avahi_dns_packet_consume_name(p, t, sizeof(t)) == 0);
+    res = avahi_dns_packet_consume_name(p, t, sizeof(t));
+    assert(res == 0);
     avahi_log_debug(">%s<", t);
     assert(avahi_domain_equal(b, t));
 
-    assert(avahi_dns_packet_consume_name(p, t, sizeof(t)) == 0);
+    res = avahi_dns_packet_consume_name(p, t, sizeof(t));
+    assert(res == 0);
     avahi_log_debug(">%s<", t);
     assert(avahi_domain_equal(c, t));
 
-    assert(avahi_dns_packet_consume_name(p, t, sizeof(t)) == 0);
+    res = avahi_dns_packet_consume_name(p, t, sizeof(t));
+    assert(res == 0);
     avahi_log_debug(">%s<", t);
     assert(avahi_domain_equal(d, t));
 
@@ -81,7 +90,8 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     r->data.hinfo.os = avahi_strdup("BAR");
 
     /* Serialize it into a blob */
-    assert((l = avahi_rdata_serialize(r, rdata, sizeof(rdata))) != (size_t) -1);
+    l = avahi_rdata_serialize(r, rdata, sizeof(rdata));
+    assert(l != (size_t) -1);
 
     /* Print it */
     avahi_hexdump(rdata, l);
@@ -89,7 +99,8 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     /* Create a new record and fill in the data from the blob */
     r2 = avahi_record_new(r->key, AVAHI_DEFAULT_TTL);
     assert(r2);
-    assert(avahi_rdata_parse(r2, rdata, l) >= 0);
+    res = avahi_rdata_parse(r2, rdata, l);
+    assert(res >= 0);
 
     /* Compare both versions */
     assert(avahi_record_equal_no_ttl(r, r2));
@@ -101,7 +112,8 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     r = avahi_record_new_full("foobar", 77, 77, AVAHI_DEFAULT_TTL);
     assert(r);
 
-    assert(r->data.generic.data = avahi_memdup("HALLO", r->data.generic.size = 5));
+    r->data.generic.data = avahi_memdup("HALLO", r->data.generic.size = 5);
+    assert(r->data.generic.data);
 
     m = avahi_record_to_string(r);
     assert(m);


### PR DESCRIPTION
to make it more likely for it to go sideways. It's prompted by a stack
overflow that started to pop up from time to time there. It's now 100%
reproducible and also call functions with side effects outside of assertions
to fix
```
==25580==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffc190c1e7f at pc 0x564e3c405cd6 bp 0x7ffc190b1780 sp 0x7ffc190b1778
READ of size 1 at 0x7ffc190c1e7f thread T0
    #0 0x564e3c405cd5 in avahi_hexdump /home/runner/work/avahi/avahi/avahi-core/util.c:44:33
    #1 0x564e3c40441e in main /home/runner/work/avahi/avahi/avahi-core/dns-test.c:87:5
    #2 0x7f8fb5e2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #3 0x7f8fb5e2a28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #4 0x564e3c31e4d4 in _start (/home/runner/work/avahi/avahi/avahi-core/.libs/dns-test+0x3e4d4) (BuildId: ff3e8c8c7db95c37e273df31a82e91d400c93c5b)

Address 0x7ffc190c1e7f is located in stack of thread T0 at offset 66719 in frame
    #0 0x564e3c403c8f in main /home/runner/work/avahi/avahi/avahi-core/dns-test.c:39

  This frame has 2 object(s):
    [32, 1046) 't' (line 40)
    [1184, 66719) 'rdata' (line 44) <== Memory access at offset 66719 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow /home/runner/work/avahi/avahi/avahi-core/util.c:44:33 in avahi_hexdump
```