### PR TITLE
ci: adjust Valgrind wrapper for unit tests

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -35,7 +35,10 @@ if [[ "$OS" == omnios ]]; then
 fi
 
 if [[ "$VALGRIND" == true ]]; then
-    export LOG_COMPILER="valgrind --leak-check=full --track-origins=yes --track-fds=yes --error-exitcode=1"
+    LOG_COMPILER="libtool --mode=execute \
+        valgrind -s --suppressions=$(pwd)/.github/workflows/unit-tests.supp \
+        --leak-check=full --track-origins=yes --track-fds=yes --error-exitcode=1"
+    export LOG_COMPILER
 fi
 
 asan_ubsan_reports_detected() {

--- a/.github/workflows/unit-tests.supp
+++ b/.github/workflows/unit-tests.supp
@@ -1,0 +1,26 @@
+# https://github.com/avahi/avahi/issues/907
+{
+   glib-watch-test-fd-not-closed
+   CoreError:FdNotClosed
+   ...
+   src:glib-watch-test.c
+}
+
+{
+   glib-watch-test-fd-bad-use
+   CoreError:FdBadUse
+   ...
+   src:glib-watch-test.c
+}
+
+# https://github.com/avahi/avahi/issues/757
+{
+   compat-libdns_sd-memleak
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:pthread_mutexattr_init
+   fun:sdref_new
+   ...
+   fun:main
+}


### PR DESCRIPTION
to take wrapper scripts generated by libtool into account. The CI missed
```
==735990== Conditional jump or move depends on uninitialised value(s)
==735990==    at 0x485ACE9: strlen (vg_replace_strmem.c:506)
==735990==    by 0x48E71CF: __printf_buffer (vfprintf-process-arg.c:443)
==735990==    by 0x490B70A: __vsnprintf_internal (vsnprintf.c:96)
==735990==    by 0x490B70A: vsnprintf (vsnprintf.c:103)
==735990==    by 0x40046CF: avahi_log_ap (log.c:38)
==735990==    by 0x4004B0B: avahi_log_debug (log.c:84)
==735990==    by 0x40042E5: main (dns-test.c:58)
==735990==  Uninitialised value was created by a stack allocation
==735990==    at 0x4004257: main (dns-test.c:39)
```
because of that recently.

Two tests fail currently. Those failures need looking into but until then they are suppressed to let the CI catch issues in more important parts of the codebase.