### PR TITLE
core: fill out msg_controllen for IPV6_PKTINFO control messages correctly

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -22,16 +22,22 @@ else
     OS=$(uname -s | tr "[:upper:]" "[:lower:]")
 fi
 
-if [[ "$OS" =~ (alpine|netbsd|omnios) ]]; then
+if [[ "$OS" =~ (alpine|netbsd|omnios|openbsd) ]]; then
     NSS_MDNS=false
 fi
 
-if [[ "$OS" =~ (freebsd|netbsd|omnios) ]]; then
+if [[ "$OS" =~ (freebsd|netbsd|omnios|openbsd) ]]; then
     MAKE=gmake
 fi
 
 if [[ "$OS" == omnios ]]; then
     PATH="/opt/local/sbin:/opt/local/bin:$PATH"
+fi
+
+if [[ "$OS" == openbsd ]]; then
+    export AUTOCONF_VERSION=2.72
+    export AUTOMAKE_VERSION=1.18
+    export MALLOC_OPTIONS=CFGJRSUX
 fi
 
 if [[ "$VALGRIND" == true ]]; then
@@ -173,6 +179,10 @@ case "$1" in
         pkg install gcc14
         install_dfuzzer
         ;;
+    install-build-deps-openbsd)
+        pkg_add -U "autoconf-${AUTOCONF_VERSION}p0" "automake-${AUTOMAKE_VERSION}" dbus drill git glib2 \
+            gmake intltool libdaemon libtool socat xmltoman
+        ;;
     build)
         if [[ "$OS" == freebsd ]]; then
             # Do what USES="localbase:ldflags" do in FreeBSD Ports, namely:
@@ -185,6 +195,10 @@ case "$1" in
             export CFLAGS+=" -I/opt/local/include"
             export CPPFLAGS+=" -I/opt/local/include"
             export LDFLAGS+=" -L/opt/local/lib"
+        elif [[ "$OS" == openbsd ]]; then
+            export CFLAGS+=" -I/usr/local/include"
+            export CPPFLAGS+=" -I/usr/local/include"
+            export LDFLAGS+=" -L/usr/local/lib"
         fi
 
         if [[ "$ASAN_UBSAN" == true ]]; then
@@ -284,6 +298,27 @@ case "$1" in
                 "--disable-libevent"
                 "--disable-libsystemd"
                 "--disable-manpages"
+                "--disable-mono"
+                "--disable-python"
+                "--disable-qt3"
+                "--disable-qt4"
+                "--disable-qt5"
+            )
+        elif [[ "$OS" == openbsd ]]; then
+            autogen_args+=(
+                "--prefix=/usr/local"
+                "--runstatedir=/var/run"
+                "--sysconfdir=/etc"
+                "--with-distro=none"
+                "--enable-tests"
+                "--disable-autoipd"
+                "--disable-compat-howl"
+                "--disable-gdbm"
+                "--disable-gobject"
+                "--disable-gtk"
+                "--disable-gtk3"
+                "--disable-libevent"
+                "--disable-libsystemd"
                 "--disable-mono"
                 "--disable-python"
                 "--disable-qt3"
@@ -431,7 +466,7 @@ EOL
 EOL
 
         $MAKE install
-        if [[ ! "$OS" =~ (netbsd|omnios) ]]; then
+        if [[ ! "$OS" =~ (netbsd|omnios|openbsd) ]]; then
             ldconfig
         fi
 
@@ -472,6 +507,10 @@ EOL
             groupadd avahi
             useradd -m -g avahi avahi
             svcadm restart dbus
+        elif [[ "$OS" == openbsd ]]; then
+            groupadd avahi
+            useradd -m -g avahi avahi
+            rcctl -d start messagebus
         else
             adduser --system --group avahi
             systemctl reload dbus

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,9 @@ jobs:
           - os: 'omnios'
             version: 'r151056'
             env: { CC: "gcc" }
+          - os: 'openbsd'
+            version: '7.8'
+            env: { CC: "clang" }
     env: ${{ matrix.env }}
     steps:
       - name: Repository checkout

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -9,8 +9,22 @@ export LD_PRELOAD=${LD_PRELOAD:-}
 export NSS_MDNS_BUILD_DIR=
 export ASAN_RT_PATH=
 
+# On OpenBSD LD_PRELOAD= is handled differently so it
+# should be unset to prevent all the things from failing with
+#
+# LD_PRELOAD= avahi-daemon -c
+# ld.so: avahi-daemon: can't preload library ''
+# Killed                     LD_PRELOAD= avahi-daemon -c
+#
+# LD_PRELOAD is needed in the ASan/UBSan nss-mdns tests and
+# they are just skipped on OpenBSD but they should be reworked
+# to run the part where IsNSSSupportAvailable is tested.
+if [[ "$OS" == openbsd ]]; then
+    unset LD_PRELOAD
+fi
+
 runstatedir=/run
-if [[ "$OS" =~ (freebsd|netbsd|omnios) ]]; then
+if [[ "$OS" =~ (freebsd|netbsd|omnios|openbsd) ]]; then
     runstatedir=/var/run
 fi
 sysconfdir=/etc
@@ -219,7 +233,9 @@ check_rlimit_nofile() {
     [[ "$_rlimit_nofile" == "$_rlimit_nofile_conf" ]]
 }
 
-install_nss_mdns
+if [[ "$OS" != openbsd ]]; then
+    install_nss_mdns
+fi
 
 run avahi-daemon -h
 run avahi-daemon -V
@@ -231,7 +247,9 @@ if [[ "$WITH_DBUS" == true ]]; then
     done
 fi
 
-run_nss_tests
+if [[ "$OS" != openbsd ]]; then
+    run_nss_tests
+fi
 
 if [[ "$WITH_SYSTEMD" == false ]]; then
     if [[ "$VALGRIND" == true ]]; then
@@ -259,7 +277,7 @@ fi
 if [[ "$WITH_DBUS" == true ]]; then
     run ./avahi-client/client-test
 
-    if [[ ! "$OS" =~ (alpine|omnios) ]]; then
+    if [[ ! "$OS" =~ (alpine|omnios|openbsd) ]]; then
         run ./avahi-compat-howl/address-test
     fi
 
@@ -269,7 +287,7 @@ if [[ "$WITH_DBUS" == true ]]; then
 
     run ./examples/glib-integration
 
-    if [[ ! "$OS" =~ (freebsd|netbsd|omnios) ]]; then
+    if [[ ! "$OS" =~ (freebsd|netbsd|omnios|openbsd) ]]; then
         run ./tests/c-plus-plus-test
     fi
 fi
@@ -281,7 +299,9 @@ for test_case in self_loop retransmit_cname one_normal one_loop two_normal two_l
     run ./avahi-core/cname-test $test_case
 done
 
-run_nss_tests
+if [[ "$OS" != openbsd ]]; then
+    run_nss_tests
+fi
 
 # make sure avahi picks up services it's notified about
 cat <<'EOL' >"$sysconfdir/avahi/services/test-notifications.service"

--- a/avahi-core/socket.c
+++ b/avahi-core/socket.c
@@ -584,7 +584,10 @@ int avahi_send_dns_packet_ipv6(
     struct msghdr msg;
     struct iovec io;
     struct cmsghdr *cmsg;
-    size_t cmsg_data[(CMSG_SPACE(sizeof(struct in6_pktinfo))/sizeof(size_t)) + 1];
+    union {
+        uint8_t cmsg_data[CMSG_SPACE(sizeof(struct in6_pktinfo))];
+        struct cmsghdr hdr;
+    } u;
 
     assert(fd >= 0);
     assert(p);
@@ -610,12 +613,12 @@ int avahi_send_dns_packet_ipv6(
     if (interface > 0 || src_address) {
         struct in6_pktinfo *pkti;
 
-        memset(cmsg_data, 0, sizeof(cmsg_data));
-        msg.msg_control = cmsg_data;
-        msg.msg_controllen = CMSG_LEN(sizeof(struct in6_pktinfo));
+        memset(u.cmsg_data, 0, sizeof(u.cmsg_data));
+        msg.msg_control = u.cmsg_data;
+        msg.msg_controllen = sizeof(u.cmsg_data);
 
         cmsg = CMSG_FIRSTHDR(&msg);
-        cmsg->cmsg_len = msg.msg_controllen;
+        cmsg->cmsg_len = CMSG_LEN(sizeof(struct in6_pktinfo));
         cmsg->cmsg_level = IPPROTO_IPV6;
         cmsg->cmsg_type = IPV6_PKTINFO;
 


### PR DESCRIPTION
to prevent avahi_send_dns_packet_ipv6 from failing on systems where the
length is strictly validated. For example without this patch on OpenBSD
all the attempts to send packets over IPv6 get rejected with
```
CALL  sendmsg(13,0x7d91b98158c8,0)
STRU  struct msghdr { name=0x7d91b98158f8, namelen=28, iov=0x7d91b98158b8, iovlen=1, control=0x7d91b9815880, controllen=36, flags=0 }
STRU  struct iovec { base=0x8f99574c030, len=228 }
STRU  struct sockaddr { AF_INET6, [ff02::fb]:5353 }
STRU  struct cmsghdr { len=36, level=41<ipv6>, type=46 }
RET   sendmsg -1 errno 22 Invalid argument
```
It has been addressed downstream with a similar patch:
https://github.com/openbsd/ports/blob/92b23c283dfd8173e6035db42b5ec82acad64ae8/net/avahi/patches/patch-avahi-core_socket_c

OpenBSD is rolled out to make sure it's buildable and releasable there.