### PR TITLE
core: free copy's HINFO 'os' field on rdata copy failure

### DIFF
--- a/avahi-core/rr.c
+++ b/avahi-core/rr.c
@@ -450,7 +450,7 @@ AvahiRecord *avahi_record_copy(AvahiRecord *r) {
                 goto fail;
 
             if (!(copy->data.hinfo.cpu = avahi_strdup(r->data.hinfo.cpu))) {
-                avahi_free(r->data.hinfo.os);
+                avahi_free(copy->data.hinfo.os);
                 goto fail;
             }
             break;


### PR DESCRIPTION
### Summary

In `avahi_record_copy()` (avahi-core/rr.c) the HINFO branch allocates
two strings, one for the copy's `data.hinfo.os` and one for
`data.hinfo.cpu`. When the second `avahi_strdup()` call fails, the
existing error path frees the wrong pointer: it calls
`avahi_free(r->data.hinfo.os)` on the *source* record's field instead
of `avahi_free(copy->data.hinfo.os)`.

avahi-core/rr.c:452-455 (before patch):

```c
if (!(copy->data.hinfo.cpu = avahi_strdup(r->data.hinfo.cpu))) {
    avahi_free(r->data.hinfo.os);
    goto fail;
}
```

`r` is the source record, still live and still owned by the caller
(e.g. `make_goodbye_record()` in avahi-core/announce.c:366). Freeing
its `hinfo.os` field has three consequences:

1. The source record is left with a dangling, non-NULL
   `data.hinfo.os` pointer.
2. The copy's `data.hinfo.os`, which was just allocated on the line
   above, is leaked (`fail:` only frees `copy->key` and `copy` itself,
   not its rdata fields).
3. When the source record is later destroyed via
   `avahi_record_unref()` (avahi-core/rr.c:147), it calls
   `avahi_free(r->data.hinfo.os)` on the already-freed pointer,
   producing a double-free.

### How to observe

A standalone reproducer that mirrors the snippet against a tracking
allocator (NULL-on-Nth-allocation, abort-on-wrong-free) deterministically
triggers the fault. With the current code:

```
BUGGY:  calling unref_src() - expect FAULT...
FAULT: xfree(0x100749c30) on a pointer not in the live set
       (double-free or wrong-pointer free)
BUGGY:  after failed copy, src->hinfo.os = 0x100749c30 (dangling)
BUGGY:  after failed copy, copy.hinfo.os = 0x100749c40 (leaked)
```

After the patch the same reproducer completes cleanly with no live
allocations.

In practice the second `avahi_strdup()` returns NULL whenever a
custom allocator installed via `avahi_set_allocator()` reports OOM;
the default allocator aborts on failure so the path is not directly
reachable there, but the freed-wrong-pointer logic is incorrect
regardless of the allocator in use.

### Fix

Free `copy->data.hinfo.os` (the field that was actually allocated
into) rather than `r->data.hinfo.os`. The change is local to the
callee and does not affect any successful path.

### Build / test

`avahi-core/rr.c` compiles cleanly with the patch applied.