### PR TITLE
compat-libdns_sd: bound trailing-dot strcat in service_resolver_callback

### DIFF
--- a/avahi-compat-libdns_sd/compat.c
+++ b/avahi-compat-libdns_sd/compat.c
@@ -708,7 +708,13 @@ static void service_resolver_callback(
             ret = avahi_service_name_join(full_name, sizeof(full_name), name, type, domain);
             assert(ret == AVAHI_OK);
 
-            strcat(full_name, ".");
+            {
+                size_t flen = strlen(full_name);
+                if (flen + 1 < sizeof(full_name)) {
+                    full_name[flen]     = '.';
+                    full_name[flen + 1] = 0;
+                }
+            }
 
             sdref->service_resolver_callback(sdref, 0, interface, kDNSServiceErr_NoError, full_name, host_name, htons(port), l, (unsigned char*) p, sdref->context);
 


### PR DESCRIPTION
avahi_service_name_join() snprintfs into full_name (a stack buffer of
AVAHI_DOMAIN_NAME_MAX bytes) and silently truncates when the joined
name would exceed that limit. When a resolved service's type+domain
push the joined name to the limit, the following strcat(full_name,
".") writes one byte past the buffer end. Reproduced locally against
the real avahi_service_name_join; append the dot only when there is
room in the buffer.