### PR TITLE
common: fix pointer-before-start UB in drop_incomplete_utf8

### DIFF
--- a/avahi-common/alternative-test.c
+++ b/avahi-common/alternative-test.c
@@ -91,6 +91,12 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
 
     avahi_alternative_service_name("\xc1\x0a");
 
+    /* These reach drop_incomplete_utf8() with an empty string (via
+       avahi_strndup(s, 0)), which used to form a pointer before the start
+       of the buffer. */
+    avahi_free(avahi_alternative_service_name(" #1"));
+    avahi_free(avahi_alternative_host_name("-2"));
+
     avahi_free(r);
     return 0;
 }

--- a/avahi-common/alternative-test.c
+++ b/avahi-common/alternative-test.c
@@ -22,6 +22,7 @@
 #endif
 
 #include <stdio.h>
+#include <string.h>
 
 #include "alternative.h"
 #include "malloc.h"
@@ -93,9 +94,18 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
 
     /* These reach drop_incomplete_utf8() with an empty string (via
        avahi_strndup(s, 0)), which used to form a pointer before the start
-       of the buffer. */
-    avahi_free(avahi_alternative_service_name(" #1"));
-    avahi_free(avahi_alternative_host_name("-2"));
+       of the buffer. Check the results, not just that they don't crash. */
+    {
+        char *n;
+
+        n = avahi_alternative_service_name(" #1");
+        assert(n && !strcmp(n, " #2"));
+        avahi_free(n);
+
+        n = avahi_alternative_host_name("-2");
+        assert(n && !strcmp(n, "-3"));
+        avahi_free(n);
+    }
 
     avahi_free(r);
     return 0;

--- a/avahi-common/alternative.c
+++ b/avahi-common/alternative.c
@@ -35,17 +35,16 @@
 static void drop_incomplete_utf8(char *c) {
     char *e;
 
-    e = strchr(c, 0) - 1;
+    e = strchr(c, 0);
 
-    while (e >= c) {
+    while (e > c) {
+        e--;
 
         if (avahi_utf8_valid(c))
             break;
 
         assert(*e & 128);
         *e = 0;
-
-        e--;
     }
 }
 


### PR DESCRIPTION
drop_incomplete_utf8() computes `strchr(c, 0) - 1`, which is undefined
when c is empty. The empty case is reached from
avahi_alternative_service_name(" #N") and avahi_alternative_host_name("-N")
via avahi_strndup(s, 0); fuzz-domain exercises both entry points.