### PR TITLE
ci: add preliminary failure injection infrastructure 

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,5 +1,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder:ubuntu-24-04
 ENV MERGE_WITH_OSS_FUZZ_CORPORA=yes
+ENV TURN_ON_NALLOCFUZZ=yes
 COPY . $SRC/avahi
 WORKDIR $SRC/avahi
 COPY fuzz/oss-fuzz.sh $SRC/build.sh

--- a/avahi-common/alternative.c
+++ b/avahi-common/alternative.c
@@ -118,12 +118,16 @@ char *avahi_alternative_host_name(const char *s) {
         avahi_free(c);
     }
 
+    if (!r)
+        return NULL;
+
     alt = alternative;
     len = sizeof(alternative);
     ret = avahi_escape_label(r, strlen(r), &alt, &len);
 
     avahi_free(r);
-    r = avahi_strdup(ret);
+    if (!(r = avahi_strdup(ret)))
+        return NULL;
 
     assert(avahi_is_valid_host_name(r));
 
@@ -195,6 +199,9 @@ char *avahi_alternative_service_name(const char *s) {
         r = avahi_strdup_printf("%s #2", c);
         avahi_free(c);
     }
+
+    if (!r)
+        return NULL;
 
     assert(avahi_is_valid_service_name(r));
 

--- a/fuzz/fuzz-domain.c
+++ b/fuzz/fuzz-domain.c
@@ -25,6 +25,25 @@
 #include "avahi-common/malloc.h"
 #include "avahi-common/domain.h"
 
+#ifdef HAVE_NALLOCFUZZ
+
+#include "nallocinc.c"
+
+static AvahiAllocator allocator = {
+    .malloc = malloc,
+    .free = free,
+    .realloc = realloc,
+    .calloc = calloc,
+};
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    nalloc_init(*argv[0]);
+    if (strstr(*argv[0], "nallocfuzz"))
+        avahi_set_allocator(&allocator);
+    return 0;
+}
+
+#endif
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     char *s = NULL, *t = NULL;
@@ -34,6 +53,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     memcpy(s, data, size);
     s[size] = '\0';
+
+#ifdef HAVE_NALLOCFUZZ
+    nalloc_start(data, size);
+#endif
 
     if ((t = avahi_normalize_name_strdup(s)))
         assert(avahi_domain_equal(s, t));
@@ -51,6 +74,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     avahi_free(t);
     avahi_free(s);
+
+#ifdef HAVE_NALLOCFUZZ
+    nalloc_end();
+#endif
 
     return 0;
 }

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -44,6 +44,8 @@ export LIB_FUZZING_ENGINE=${LIB_FUZZING_ENGINE:--fsanitize=fuzzer}
 
 export MERGE_WITH_OSS_FUZZ_CORPORA=${MERGE_WITH_OSS_FUZZ_CORPORA:-no}
 
+export TURN_ON_NALLOCFUZZ=${TURN_ON_NALLOCFUZZ:-no}
+
 if [[ -n "${FUZZING_ENGINE:-}" ]]; then
     apt-get update
     apt-get install -y autoconf gettext libtool m4 automake pkg-config libexpat-dev zipmerge
@@ -83,6 +85,20 @@ fi
 
 make -j"$(nproc)" V=1
 
+if [[ "$TURN_ON_NALLOCFUZZ" == yes ]]; then
+    # It's the official nallocfuzz repository but it can diverge
+    # from its battle-tested copy in Suricata. For example
+    # https://github.com/catenacyber/nallocfuzz/issues/6 is already
+    # addressed in Suricata.
+    git clone https://github.com/catenacyber/nallocfuzz
+    pushd nallocfuzz
+    git checkout 190f87c0b1d4250d03a8c92cc80184bd8241c83d
+    cp nallocinc.c ../fuzz
+    popd
+    CFLAGS="-DHAVE_NALLOCFUZZ $CFLAGS"
+    CXXFLAGS="-DHAVE_NALLOCFUZZ $CXXFLAGS"
+fi
+
 for f in fuzz/fuzz-*.c; do
     fuzz_target=$(basename "$f" .c)
     additional_obj_files=
@@ -108,6 +124,10 @@ for f in fuzz/fuzz-*.c; do
         $LIB_FUZZING_ENGINE \
         $additional_obj_files \
         "avahi-core/.libs/libavahi-core.a" "avahi-common/.libs/libavahi-common.a"
+
+    if [[ "$TURN_ON_NALLOCFUZZ" == yes ]] && grep nalloc_init "$f"; then
+        cp "$OUT/$fuzz_target" "$OUT/$fuzz_target-nallocfuzz"
+    fi
 done
 
 # Let's take the systemd public corpus here. It has been accumulating since 2018
@@ -119,9 +139,13 @@ if [[ "$MERGE_WITH_OSS_FUZZ_CORPORA" == "yes" ]]; then
     for f in "$OUT/"fuzz-*; do
         [[ -x "$f" ]] || continue
         fuzzer=$(basename "$f")
+        [[ "$fuzzer" =~ "-nallocfuzz" ]] && continue
         t=$(mktemp)
         if wget -O "$t" "https://storage.googleapis.com/avahi-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/avahi_${fuzzer}/public.zip"; then
             zipmerge "$OUT/${fuzzer}_seed_corpus.zip" "$t"
+            if [[ -x "$f-nallocfuzz" ]]; then
+                cp "$OUT/${fuzzer}_seed_corpus.zip" "$OUT/${fuzzer}-nallocfuzz_seed_corpus.zip"
+            fi
         fi
         rm -rf "$t"
     done


### PR DESCRIPTION
to exercise code paths less travelled.

It's turned on on ClusterFuzzLite only for now. See
https://github.com/catenacyber/nallocfuzz/issues/6.