### PR TITLE
dns: reject oversize rdata in avahi_rdata_parse

### DIFF
--- a/avahi-core/dns-test.c
+++ b/avahi-core/dns-test.c
@@ -170,5 +170,22 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     avahi_record_unref(r);
     avahi_record_unref(r2);
 
+    /* rdata larger than the 16 bit rdlength field must be rejected, not
+     * truncated mod 65536 and parsed as a shorter record */
+    r = avahi_record_new_full("test", 77, 77, AVAHI_DEFAULT_TTL);
+    assert(r);
+
+    m = avahi_malloc0(AVAHI_DNS_RDATA_MAX + 1);
+    assert(m);
+
+    res = avahi_rdata_parse(r, m, AVAHI_DNS_RDATA_MAX + 1);
+    assert(res < 0);
+
+    res = avahi_rdata_parse(r, m, AVAHI_DNS_RDATA_MAX);
+    assert(res >= 0);
+
+    avahi_free(m);
+    avahi_record_unref(r);
+
     return 0;
 }

--- a/avahi-core/dns.c
+++ b/avahi-core/dns.c
@@ -860,6 +860,12 @@ int avahi_rdata_parse(AvahiRecord *record, const void* rdata, size_t size) {
     assert(record);
     assert(rdata);
 
+    /* rdlength is a 16 bit field on the wire and parse_rdata() takes it
+     * as a uint16_t, so anything bigger would be silently truncated and
+     * parsed as an unrelated length. Reject it instead. */
+    if (size > AVAHI_DNS_RDATA_MAX)
+        return -1;
+
     p.data = (void*) rdata;
     p.max_size = p.size = size;
     p.rindex = 0;


### PR DESCRIPTION
avahi_rdata_parse() passes its size_t size straight into parse_rdata(), whose rdlength argument is a uint16_t, so an rdata of 65536 bytes or more is truncated mod 65536 and parsed as a different (often empty) record while still returning success. It's reachable from a local client through EntryGroup.AddRecord, whose byte array goes here unchecked. Reject sizes above AVAHI_DNS_RDATA_MAX before the narrowing, matching the assert already in avahi_rdata_serialize().