### PR TITLE
pass unsigned char to ctype functions in name parsers

### DIFF
--- a/avahi-common/alternative.c
+++ b/avahi-common/alternative.c
@@ -69,7 +69,7 @@ char *avahi_alternative_host_name(const char *s) {
         e++;
 
         for (p = e; *p; p++)
-            if (!isdigit(*p)) {
+            if (!isdigit((unsigned char) *p)) {
                 e = NULL;
                 break;
             }
@@ -151,7 +151,7 @@ char *avahi_alternative_service_name(const char *s) {
             e = n + 2;
 
         for (p = e; *p; p++)
-            if (!isdigit(*p)) {
+            if (!isdigit((unsigned char) *p)) {
                 e = NULL;
                 break;
             }

--- a/avahi-common/domain-test.c
+++ b/avahi-common/domain-test.c
@@ -68,6 +68,14 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
 
     printf("%u = %u\n", avahi_domain_hash("ccc\\065aa.aa\\.b\\\\."), avahi_domain_hash("cccAaa.aa\\.b\\\\"));
 
+    /* High-bit bytes (valid UTF-8 names) reach isdigit()/tolower(); these must
+       be passed as unsigned char, not as a (possibly negative) plain char. */
+    {
+        const char *q = "x\\\303y";
+        assert(avahi_unescape_label(&q, t, sizeof(t)) == NULL);
+    }
+    assert(avahi_domain_hash("\303\244\303\266.local") == avahi_domain_hash("\303\244\303\266.local"));
+
 
     avahi_service_name_join(t, sizeof(t), "foo.foo.foo \\.", "_http._tcp", "test.local");
     printf("<%s>\n", t);

--- a/avahi-common/domain.c
+++ b/avahi-common/domain.c
@@ -73,12 +73,12 @@ char *avahi_unescape_label(const char **name, char *dest, size_t size) {
                 /* Escaped backslash or dot */
                 *(d++) = *((*name) ++);
                 i++;
-            } else if (isdigit(**name)) {
+            } else if (isdigit((unsigned char) **name)) {
                 int n;
 
                 /* Escaped literal ASCII character */
 
-                if (!isdigit(*(*name+1)) || !isdigit(*(*name+2)))
+                if (!isdigit((unsigned char) *(*name+1)) || !isdigit((unsigned char) *(*name+2)))
                     return NULL;
 
                 n = ((uint8_t) (**name - '0') * 100) + ((uint8_t) (*(*name+1) - '0') * 10) + ((uint8_t) (*(*name +2) - '0'));
@@ -432,7 +432,7 @@ unsigned avahi_domain_hash(const char *s) {
         assert(r);
 
         for (p = c; *p; p++)
-            hash = 31 * hash + tolower(*p);
+            hash = 31 * hash + tolower((unsigned char) *p);
     }
 
     return hash;

--- a/avahi-core/util.c
+++ b/avahi-core/util.c
@@ -104,7 +104,7 @@ char *avahi_strup(char *s) {
     assert(s);
 
     for (c = s; *c; c++)
-        *c = (char) toupper(*c);
+        *c = (char) toupper((unsigned char) *c);
 
     return s;
 }
@@ -114,7 +114,7 @@ char *avahi_strdown(char *s) {
     assert(s);
 
     for (c = s; *c; c++)
-        *c = (char) tolower(*c);
+        *c = (char) tolower((unsigned char) *c);
 
     return s;
 }


### PR DESCRIPTION
Noticed `avahi_unescape_label` and `avahi_domain_hash` hand a plain `char` to isdigit/tolower. On signed-char platforms a high-bit byte from a UTF-8 name goes negative, which is undefined per C11 7.4 and indexes the ctype table out of bounds. Those names come straight off the wire, and domain_hash backs the cache/entry hashmap keys. Cast to unsigned char here and at the matching sites in avahi_alternative_* and avahi_str{up,down}. Added a domain-test case covering a backslash-escaped high byte and a UTF-8 hash.