### PR TITLE
avahi-browse: pass unsigned char to isprint in make_printable

### DIFF
--- a/avahi-utils/avahi-browse.c
+++ b/avahi-utils/avahi-browse.c
@@ -144,7 +144,7 @@ static char *make_printable(const char *from, char *to) {
     char *t;
 
     for (f = from, t = to; *f; f++, t++)
-        *t = isprint(*f) ? *f : '_';
+        *t = isprint((unsigned char) *f) ? *f : '_';
 
     *t = 0;
 


### PR DESCRIPTION
make_printable in avahi-browse hands a plain char to isprint, so a service name carrying a high-bit UTF-8 byte (any accented name, since valid service names only need to be valid UTF-8) passes isprint a negative value on signed-char builds, which is undefined behaviour per the ctype contract and an out-of-bounds table read on some libcs. I hit it reading back through the ctype call sites looking for ones that take untrusted bytes. Casting to unsigned char before the call keeps the output identical for normal characters while dropping the UB.