### PR TITLE
core: set scope ids for link-local IPv6 addresses 

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -180,6 +180,7 @@ case "$1" in
         install_dfuzzer
         ;;
     install-build-deps-openbsd)
+        PKG_PATH="installpath:https://cdn.openbsd.org/%m" \
         pkg_add -U "autoconf-${AUTOCONF_VERSION}p0" "automake-${AUTOMAKE_VERSION}.1" dbus drill git glib2 \
             gmake intltool libdaemon libtool socat xmltoman
         ;;

--- a/avahi-core/socket.c
+++ b/avahi-core/socket.c
@@ -596,8 +596,11 @@ int avahi_send_dns_packet_ipv6(
 
     if (!dst_address)
         mdns_mcast_group_ipv6(&sa);
-    else
+    else {
         ipv6_address_to_sockaddr(&sa, dst_address, dst_port);
+        if (interface > 0 && IN6_IS_ADDR_LINKLOCAL(&sa.sin6_addr))
+            sa.sin6_scope_id = interface;
+    }
 
     memset(&io, 0, sizeof(io));
     io.iov_base = AVAHI_DNS_PACKET_DATA(p);


### PR DESCRIPTION
to prevent avahi_send_dns_packet_ipv6 from failing on OpenBSD with:
```
 88705 avahi-daemon CALL  sendmsg(13,0x7f3af15275d8,0)
 88705 avahi-daemon STRU  struct msghdr { name=0x7f3af1527608, namelen=28, iov=0x7f3af15275c8, iovlen=1, control=0x7f3af1527598, controllen=40, flags=0 }
 88705 avahi-daemon STRU  struct iovec { base=0x8ee20a522b0, len=82 }
 88705 avahi-daemon STRU  struct sockaddr { AF_INET6, [fe80::*]:37230 }
 88705 avahi-daemon STRU  struct cmsghdr { len=36, level=41<ipv6>, type=46 }
 88705 avahi-daemon RET   sendmsg -1 errno 65 No route to host
```
when it sends replies to link-local IPv6 addresses.