### PR TITLE
core: no longer read past netmask in ip6_masklen

### DIFF
--- a/avahi-core/iface-pfroute.c
+++ b/avahi-core/iface-pfroute.c
@@ -351,7 +351,7 @@ static int ip6_masklen (struct in6_addr netmask) {
 
     pnt = (unsigned char *) & netmask;
 
-    while ((*pnt == 0xff) && len < 128) {
+    while (len < 128 && (*pnt == 0xff)) {
         len += 8;
         pnt++;
     }


### PR DESCRIPTION
It was added in 2f111835513ceecab837cb769f0d7b6b6c80f68b and has never been actually used anywhere but it should prepare it for follow-up commits where it should replace bitcount incorrectly applied to in6_addr since it was copy-pasted from the IPv4 part in
3daec6014638cccfe205529f829bb6ef6e9383db.

Fixes:
```
==21552==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffffffd830 at pc 0x0008005ebcdd bp 0x7fffffffd7f0 sp 0x7fffffffd7e8
READ of size 1 at 0x7fffffffd830 thread T0
    #0 0x0008005ebcdc in ip6_masklen /home/vagrant/avahi/avahi-core/iface-pfroute.c:70:13
    #1 0x0008005eaa92 in rtm_addr /home/vagrant/avahi/avahi-core/iface-pfroute.c:207:16
    #2 0x0008005e81ad in parse_rtmsg /home/vagrant/avahi/avahi-core/iface-pfroute.c:279:5
    #3 0x0008005e7c8f in avahi_interface_monitor_sync /home/vagrant/avahi/avahi-core/iface-pfroute.c:491:5
    #4 0x000800501652 in avahi_server_new /home/vagrant/avahi/avahi-core/server.c:1516:5
    #5 0x00000031c079 in run_server /home/vagrant/avahi/avahi-daemon/main.c:1265:26
    #6 0x00000030de7b in main /home/vagrant/avahi/avahi-daemon/main.c:1708:13
    #7 0x00080085c37e in __libc_start1 /usr/src/lib/libc/csu/libc_start1.c:180:7
    #8 0x000000267c33 in _start /usr/src/lib/csu/amd64/crt1_s.S:80

Address 0x7fffffffd830 is located in stack of thread T0 at offset 48 in frame
    #0 0x0008005ebb9f in ip6_masklen /home/vagrant/avahi/avahi-core/iface-pfroute.c:63

  This frame has 1 object(s):
    [32, 48) 'netmask' <== Memory access at offset 48 overflows this variable
```