### PR TITLE
core: handle prefix lengths longer than 120 correctly

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -388,8 +388,7 @@ run avahi-resolve -v -a "$ipv6addr"
 
 systemd-run -u avahi-test-publish-address avahi-publish -fvaR  "$h" "$ipv4addr"
 
-# ::1 isn't here due to https://github.com/avahi/avahi/issues/574
-for s in 127.0.0.1 224.0.0.251 ff02::fb; do
+for s in 127.0.0.1 224.0.0.251 ff02::fb ::1; do
    drill -p5353 "@$s" "$h" ANY
    drill -p5353 "@$s" "_services._dns-sd._udp.local" ANY
 done

--- a/avahi-core/iface.c
+++ b/avahi-core/iface.c
@@ -805,9 +805,6 @@ int avahi_interface_address_on_link(AvahiInterface *i, const AvahiAddress *a) {
             for (j = 0; j < 16; j++) {
                 uint8_t m;
 
-                if (pl == 0)
-                    return 1;
-
                 if (pl >= 8) {
                     m = 0xFF;
                     pl -= 8;
@@ -818,6 +815,9 @@ int avahi_interface_address_on_link(AvahiInterface *i, const AvahiAddress *a) {
 
                 if ((a->data.ipv6.address[j] & m) != (ia->address.data.ipv6.address[j] & m))
                     break;
+
+                if (pl == 0)
+                    return 1;
             }
         }
     }


### PR DESCRIPTION
It's a follow-up to https://github.com/avahi/avahi/commit/9962a048634c590db23a00db1d01daada779844c.

Closes https://github.com/avahi/avahi/issues/574.

`::1` is uncommented on the CI now that avahi can handle `::1/128`