### PR TITLE
ci: cut off the _RC* part on NetBSD

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -158,7 +158,7 @@ case "$1" in
         install_radamsa
         ;;
     install-build-deps-netbsd)
-        PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r)/All/" \
+        PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|sed 's/_.*//')/All/" \
         PKG_RCD_SCRIPTS=yes \
             pkg_add -u autoconf automake dbus drill expat gettext git glib gmake intltool libdaemon libtool \
             meson pkgconf socat


### PR DESCRIPTION
to get it to work with release candidates as well. Without that it fails with
```
...
pkg_add: Can't process https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/i386/11.0_RC5/All//pkgconf*: Not Found
pkg_add: no pkg found for 'pkgconf', sorry.
pkg_add: Can't process https://cdn.NetBSD.org:443/pub/pkgsrc/packages/NetBSD/i386/11.0_RC5/All//socat*: Not Found
pkg_add: no pkg found for 'socat', sorry.
pkg_add: 15 package additions failed
```