### PR TITLE
core: add NSEC record type support to fix mDNS reflection

### DIFF
--- a/avahi-common/defs.h
+++ b/avahi-common/defs.h
@@ -335,7 +335,8 @@ enum {
     AVAHI_DNS_TYPE_MX = 0x0F,
     AVAHI_DNS_TYPE_TXT = 0x10,
     AVAHI_DNS_TYPE_AAAA = 0x1C,
-    AVAHI_DNS_TYPE_SRV = 0x21
+    AVAHI_DNS_TYPE_SRV = 0x21,
+    AVAHI_DNS_TYPE_NSEC = 0x2F  /**< NSEC record (RFC 4034) */
 };
 
 /** DNS record classes, see RFC 1035 */

--- a/avahi-core/dns-test.c
+++ b/avahi-core/dns-test.c
@@ -22,6 +22,8 @@
 #endif
 
 #include <assert.h>
+#include <stddef.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -36,11 +38,29 @@
 #include "rr-util.h"
 #include "util.h"
 
+/* Build an NSEC record with a realistic mDNS type bitmap (window block 0
+ * advertising A (type 1) and AAAA (type 28), as used in RFC 6762). */
+static AvahiRecord *make_nsec(const char *owner, const char *next_domain_name) {
+    static const uint8_t bitmap[] = { 0x00, 0x04, 0x40, 0x00, 0x00, 0x08 };
+    AvahiRecord *r;
+
+    r = avahi_record_new_full(owner, AVAHI_DNS_CLASS_IN, AVAHI_DNS_TYPE_NSEC, AVAHI_DEFAULT_TTL);
+    assert(r);
+
+    r->data.nsec.next_domain_name = avahi_strdup(next_domain_name);
+    assert(r->data.nsec.next_domain_name);
+    r->data.nsec.type_bitmap = avahi_memdup(bitmap, sizeof(bitmap));
+    assert(r->data.nsec.type_bitmap);
+    r->data.nsec.type_bitmap_size = sizeof(bitmap);
+
+    return r;
+}
+
 int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     char t[AVAHI_DOMAIN_NAME_MAX], *m;
     const char *a, *b, *c, *d;
     AvahiDnsPacket *p;
-    AvahiRecord *r, *r2;
+    AvahiRecord *r, *r2, *r3;
     uint8_t rdata[AVAHI_DNS_RDATA_MAX];
     size_t l;
     int res;
@@ -186,6 +206,170 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
 
     avahi_free(m);
     avahi_record_unref(r);
+
+    /* NSEC: isolated rdata round-trip (Next Domain Name + type bitmap) */
+    r = make_nsec("host.local", "host.local");
+
+    l = avahi_rdata_serialize(r, rdata, sizeof(rdata));
+    assert(l != (size_t) -1);
+
+    avahi_hexdump(rdata, l);
+
+    r2 = avahi_record_new(r->key, AVAHI_DEFAULT_TTL);
+    assert(r2);
+    res = avahi_rdata_parse(r2, rdata, l);
+    assert(res >= 0);
+
+    assert(avahi_record_equal_no_ttl(r, r2));
+    assert(avahi_record_lexicographical_compare(r, r2) == 0);
+
+    m = avahi_record_to_string(r);
+    assert(m);
+    avahi_log_debug(">%s<", m);
+    avahi_free(m);
+
+    avahi_record_unref(r);
+    avahi_record_unref(r2);
+
+    /* NSEC: empty type bitmap. type_bitmap is NULL with size 0, which must
+     * be handled by equal/copy/compare without dereferencing the NULL. */
+    r = avahi_record_new_full("empty.local", AVAHI_DNS_CLASS_IN, AVAHI_DNS_TYPE_NSEC, AVAHI_DEFAULT_TTL);
+    assert(r);
+    r->data.nsec.next_domain_name = avahi_strdup("empty.local");
+    assert(r->data.nsec.next_domain_name);
+    r->data.nsec.type_bitmap = NULL;
+    r->data.nsec.type_bitmap_size = 0;
+
+    l = avahi_rdata_serialize(r, rdata, sizeof(rdata));
+    assert(l != (size_t) -1);
+
+    r2 = avahi_record_new(r->key, AVAHI_DEFAULT_TTL);
+    assert(r2);
+    res = avahi_rdata_parse(r2, rdata, l);
+    assert(res >= 0);
+
+    assert(avahi_record_equal_no_ttl(r, r2));
+    assert(avahi_record_lexicographical_compare(r, r2) == 0); /* must not deref NULL bitmap */
+
+    r3 = avahi_record_copy(r);
+    assert(r3);
+    assert(avahi_record_equal_no_ttl(r, r3));
+    assert(avahi_record_lexicographical_compare(r, r3) == 0);
+
+    /* An empty bitmap must compare as smaller than a non-empty one. */
+    {
+        AvahiRecord *nonempty = make_nsec("empty.local", "empty.local");
+        assert(avahi_record_lexicographical_compare(r, nonempty) < 0);
+        assert(avahi_record_lexicographical_compare(nonempty, r) > 0);
+        avahi_record_unref(nonempty);
+    }
+
+    avahi_record_unref(r);
+    avahi_record_unref(r2);
+    avahi_record_unref(r3);
+
+    /* NSEC: compression regression test.
+     *
+     * In mDNS the NSEC Next Domain Name is usually the record's own owner
+     * name and is therefore name-compressed on the wire (RFC 6762 18.14).
+     * Avahi used to treat NSEC as opaque rdata and froze the original
+     * packet's compression pointer into the blob, then re-emitted those
+     * exact bytes when reflecting the record into a new packet -- where the
+     * same offset points at unrelated data. This test reflects an NSEC
+     * record through two packets with DIFFERENT layouts and checks the Next
+     * Domain Name survives intact. */
+    {
+        AvahiRecord *nsec, *prefix, *parsed, *skip;
+        AvahiDnsPacket *p1, *p2;
+
+        nsec = make_nsec("host.local", "host.local");
+
+        /* Packet 1: the owner name is appended first, so append_record
+         * compresses the Next Domain Name down to a pointer back to it. */
+        p1 = avahi_dns_packet_new(0);
+        assert(p1);
+        resp = avahi_dns_packet_append_record(p1, nsec, 0, 0);
+        assert(resp);
+
+        parsed = avahi_dns_packet_consume_record(p1, NULL);
+        assert(parsed);
+        assert(avahi_record_equal_no_ttl(nsec, parsed));
+
+        /* Packet 2: prepend an unrelated record so "host.local" lands at a
+         * different offset, then reflect the parsed NSEC into it. With the
+         * old code the frozen pointer would now decode to garbage. */
+        p2 = avahi_dns_packet_new(0);
+        assert(p2);
+
+        prefix = avahi_record_new_full("a.much.longer.unrelated.name.local", AVAHI_DNS_CLASS_IN, AVAHI_DNS_TYPE_PTR, AVAHI_DEFAULT_TTL);
+        assert(prefix);
+        prefix->data.ptr.name = avahi_strdup("target.local");
+        assert(prefix->data.ptr.name);
+
+        resp = avahi_dns_packet_append_record(p2, prefix, 0, 0);
+        assert(resp);
+        resp = avahi_dns_packet_append_record(p2, parsed, 0, 0);
+        assert(resp);
+
+        avahi_record_unref(parsed);
+
+        skip = avahi_dns_packet_consume_record(p2, NULL);
+        assert(skip);
+        avahi_record_unref(skip);
+
+        parsed = avahi_dns_packet_consume_record(p2, NULL);
+        assert(parsed);
+        assert(avahi_record_equal_no_ttl(nsec, parsed));
+        assert(avahi_domain_equal(parsed->data.nsec.next_domain_name, "host.local"));
+
+        avahi_record_unref(parsed);
+        avahi_record_unref(prefix);
+        avahi_record_unref(nsec);
+        avahi_dns_packet_free(p1);
+        avahi_dns_packet_free(p2);
+    }
+
+    /* NSEC: a record whose Next Domain Name arrives compressed but whose
+     * bitmap is so large that the name + bitmap would overflow the 16-bit
+     * rdata limit once the name is written back uncompressed must be
+     * rejected at parse time. Otherwise avahi_rdata_serialize() would fail
+     * on a record we had already accepted, and the record could not be
+     * reflected. On the wire the name is a 2-byte pointer, so the record
+     * fits in rdlength; only after decompression does it overflow. */
+    {
+        AvahiRecord *nsec, *parsed;
+        AvahiDnsPacket *p1;
+        size_t huge;
+
+        /* "host.local" is 12 bytes uncompressed on the wire; pick a bitmap
+         * that keeps the compressed record within rdlength (2 + bitmap <=
+         * 0xFFFF) but pushes the decompressed form (12 + bitmap) over it. */
+        huge = AVAHI_DNS_RDATA_MAX - 5;
+
+        nsec = avahi_record_new_full("host.local", AVAHI_DNS_CLASS_IN, AVAHI_DNS_TYPE_NSEC, AVAHI_DEFAULT_TTL);
+        assert(nsec);
+        nsec->data.nsec.next_domain_name = avahi_strdup("host.local");
+        assert(nsec->data.nsec.next_domain_name);
+        nsec->data.nsec.type_bitmap = avahi_malloc0(huge);
+        assert(nsec->data.nsec.type_bitmap);
+        nsec->data.nsec.type_bitmap_size = (uint16_t) huge;
+
+        p1 = avahi_dns_packet_new(0);
+        assert(p1);
+
+        /* append_record compresses the Next Domain Name to a 2-byte pointer
+         * back to the owner name, so the record fits on the wire. */
+        resp = avahi_dns_packet_append_record(p1, nsec, 0, 0);
+        assert(resp);
+
+        /* Consuming it must fail: the decompressed record cannot be
+         * re-serialized within the rdata limit. */
+        parsed = avahi_dns_packet_consume_record(p1, NULL);
+        assert(!parsed);
+
+        avahi_dns_packet_free(p1);
+        avahi_record_unref(nsec);
+    }
 
     return 0;
 }

--- a/avahi-core/dns.c
+++ b/avahi-core/dns.c
@@ -607,6 +607,51 @@ static int parse_rdata(AvahiDnsPacket *p, AvahiRecord *r, uint16_t rdlength) {
 
             break;
 
+        case AVAHI_DNS_TYPE_NSEC: {
+
+            if (avahi_dns_packet_consume_name(p, buf, sizeof(buf)) < 0)
+                return -1;
+
+            if (!(r->data.nsec.next_domain_name = avahi_strdup(buf)))
+                return -1;
+
+            /* Remaining bytes are the Type Bit Maps (raw, no compression) */
+            {
+                size_t consumed_after = (const uint8_t*) avahi_dns_packet_get_rptr(p) - (const uint8_t*) start;
+                uint16_t bitmap_size;
+
+                if (consumed_after > rdlength)
+                    return -1;
+
+                bitmap_size = rdlength - (uint16_t) consumed_after;
+
+                /* The name is decompressed on parse but re-serialized
+                 * uncompressed, so a name that arrived as a compression
+                 * pointer can expand and push the record past the 16-bit
+                 * rdata limit. Reject such a record now, rather than let
+                 * avahi_rdata_serialize() fail on it later, so anything we
+                 * accept can always be reflected. The uncompressed name is
+                 * at most strlen()+2 bytes on the wire and real mDNS bitmaps
+                 * are tiny, so this never rejects legitimate records. */
+                if (strlen(buf) + 2 + (size_t) bitmap_size > AVAHI_DNS_RDATA_MAX)
+                    return -1;
+
+                if (bitmap_size > 0) {
+                    r->data.nsec.type_bitmap = avahi_memdup(avahi_dns_packet_get_rptr(p), bitmap_size);
+                    if (!r->data.nsec.type_bitmap)
+                        return -1;
+
+                    if (avahi_dns_packet_skip(p, bitmap_size) < 0)
+                        return -1;
+                } else
+                    r->data.nsec.type_bitmap = NULL;
+
+                r->data.nsec.type_bitmap_size = bitmap_size;
+            }
+
+            break;
+        }
+
         default:
 
 /*             avahi_log_debug("generic"); */
@@ -778,6 +823,17 @@ static int append_rdata(AvahiDnsPacket *p, AvahiRecord *r) {
 
             if (!avahi_dns_packet_append_bytes(p, &r->data.aaaa.address, sizeof(r->data.aaaa.address)))
                 return -1;
+
+            break;
+
+        case AVAHI_DNS_TYPE_NSEC:
+
+            if (!(avahi_dns_packet_append_name(p, r->data.nsec.next_domain_name)))
+                return -1;
+
+            if (r->data.nsec.type_bitmap_size > 0)
+                if (!avahi_dns_packet_append_bytes(p, r->data.nsec.type_bitmap, r->data.nsec.type_bitmap_size))
+                    return -1;
 
             break;
 

--- a/avahi-core/rr.c
+++ b/avahi-core/rr.c
@@ -174,6 +174,11 @@ void avahi_record_unref(AvahiRecord *r) {
             case AVAHI_DNS_TYPE_AAAA:
                 break;
 
+            case AVAHI_DNS_TYPE_NSEC:
+                avahi_free(r->data.nsec.next_domain_name);
+                avahi_free(r->data.nsec.type_bitmap);
+                break;
+
             default:
                 avahi_free(r->data.generic.data);
         }
@@ -219,6 +224,8 @@ const char *avahi_dns_type_to_string(uint16_t type) {
             return "SOA";
         case AVAHI_DNS_TYPE_NS:
             return "NS";
+        case AVAHI_DNS_TYPE_NSEC:
+            return "NSEC";
         default:
             return NULL;
     }
@@ -285,6 +292,14 @@ char *avahi_record_to_string(const AvahiRecord *r) {
                      r->data.srv.weight,
                      r->data.srv.port,
                      r->data.srv.name);
+
+            break;
+
+        case AVAHI_DNS_TYPE_NSEC:
+
+            snprintf(t = buf, sizeof(buf), "%s [bitmap %u bytes]",
+                     r->data.nsec.next_domain_name,
+                     r->data.nsec.type_bitmap_size);
 
             break;
 
@@ -396,6 +411,11 @@ static int rdata_equal(const AvahiRecord *a, const AvahiRecord *b) {
         case AVAHI_DNS_TYPE_AAAA:
             return memcmp(&a->data.aaaa.address, &b->data.aaaa.address, sizeof(AvahiIPv6Address)) == 0;
 
+        case AVAHI_DNS_TYPE_NSEC:
+            return avahi_domain_equal(a->data.nsec.next_domain_name, b->data.nsec.next_domain_name) &&
+                a->data.nsec.type_bitmap_size == b->data.nsec.type_bitmap_size &&
+                (a->data.nsec.type_bitmap_size == 0 || memcmp(a->data.nsec.type_bitmap, b->data.nsec.type_bitmap, a->data.nsec.type_bitmap_size) == 0);
+
         default:
             return a->data.generic.size == b->data.generic.size &&
                 (a->data.generic.size == 0 || memcmp(a->data.generic.data, b->data.generic.data, a->data.generic.size) == 0);
@@ -467,6 +487,19 @@ AvahiRecord *avahi_record_copy(AvahiRecord *r) {
             copy->data.aaaa.address = r->data.aaaa.address;
             break;
 
+        case AVAHI_DNS_TYPE_NSEC:
+            if (!(copy->data.nsec.next_domain_name = avahi_strdup(r->data.nsec.next_domain_name)))
+                goto fail;
+            if (r->data.nsec.type_bitmap_size > 0) {
+                if (!(copy->data.nsec.type_bitmap = avahi_memdup(r->data.nsec.type_bitmap, r->data.nsec.type_bitmap_size))) {
+                    avahi_free(copy->data.nsec.next_domain_name);
+                    goto fail;
+                }
+            } else
+                copy->data.nsec.type_bitmap = NULL;
+            copy->data.nsec.type_bitmap_size = r->data.nsec.type_bitmap_size;
+            break;
+
         default:
             if (r->data.generic.size && !(copy->data.generic.data = avahi_memdup(r->data.generic.data, r->data.generic.size)))
                 goto fail;
@@ -524,6 +557,10 @@ size_t avahi_record_get_estimate_size(AvahiRecord *r) {
 
         case AVAHI_DNS_TYPE_AAAA:
             n += sizeof(AvahiIPv6Address);
+            break;
+
+        case AVAHI_DNS_TYPE_NSEC:
+            n += strlen(r->data.nsec.next_domain_name) + 1 + r->data.nsec.type_bitmap_size;
             break;
 
         default:
@@ -640,6 +677,31 @@ int avahi_record_lexicographical_compare(AvahiRecord *a, AvahiRecord *b) {
         case AVAHI_DNS_TYPE_AAAA:
             return memcmp(&a->data.aaaa.address, &b->data.aaaa.address, sizeof(AvahiIPv6Address));
 
+        case AVAHI_DNS_TYPE_NSEC: {
+            size_t asize, bsize;
+
+            if ((r = avahi_binary_domain_cmp(a->data.nsec.next_domain_name, b->data.nsec.next_domain_name)))
+                return r;
+
+            /* The type bitmap may be empty, in which case type_bitmap is
+             * NULL; lexicographical_memcmp() asserts non-NULL operands, so
+             * handle the empty cases explicitly like the other variable
+             * length types above. */
+            asize = a->data.nsec.type_bitmap_size;
+            bsize = b->data.nsec.type_bitmap_size;
+
+            if (asize && bsize)
+                r = lexicographical_memcmp(a->data.nsec.type_bitmap, asize, b->data.nsec.type_bitmap, bsize);
+            else if (asize && !bsize)
+                r = 1;
+            else if (!asize && bsize)
+                r = -1;
+            else
+                r = 0;
+
+            return r;
+        }
+
         default: {
             size_t asize, bsize;
 
@@ -695,6 +757,9 @@ int avahi_record_is_valid(AvahiRecord *r) {
 
         case AVAHI_DNS_TYPE_SRV:
             return avahi_is_valid_domain_name(r->data.srv.name);
+
+        case AVAHI_DNS_TYPE_NSEC:
+            return avahi_is_valid_domain_name(r->data.nsec.next_domain_name);
 
         case AVAHI_DNS_TYPE_HINFO:
             return

--- a/avahi-core/rr.h
+++ b/avahi-core/rr.h
@@ -103,6 +103,12 @@ typedef struct AvahiRecord {
             AvahiIPv6Address address;
         } aaaa; /**< Data for AAAA records */
 
+        struct {
+            char *next_domain_name;
+            uint8_t *type_bitmap;
+            uint16_t type_bitmap_size;
+        } nsec; /**< Data for NSEC records */
+
     } data; /**< Record data */
 
 } AvahiRecord;


### PR DESCRIPTION
Fixes #379.

## Summary

Avahi parses NSEC (type 47) as opaque rdata. But an NSEC record starts with a domain name (the Next Domain Name) that mDNS name-compresses (RFC 6762 §18.14), so storing it as raw bytes freezes the source packet's compression pointer into the blob. On reflection that pointer is re-emitted at a different offset, where it points at unrelated data — the record decodes to garbage and Wireshark flags the reflected packet as malformed.

This makes NSEC a first-class type like PTR/CNAME/SRV/NS: the Next Domain Name is decompressed on parse and re-compressed for the destination packet on serialize, with the type bitmap kept as raw bytes. Parse also rejects any NSEC that couldn't be re-serialized within the 16-bit rdata limit, so anything we accept can always be reflected.

I stumbled upon #379 as I noticed Avahi's reflected mDNS traffic was being flagged as malformed by Wireshark when I was investigating why my Brother printer wasn't being discovered correctly. I can confirm that this PR fixes both the printer discovery issue and Wireshark's malformed check.

## Tests

`avahi-core/dns-test.c` adds: rdata round-trip, empty bitmap, a compression regression (reflect through two differently-laid-out packets), and oversize rejection. Clean under `-Wall -Wextra -Werror`; passes under ASan/UBSan.

No fuzzing changes needed as a coverage build confirms the existing `fuzz-consume-record`/`fuzz-packet` targets reach the new code naturally (~16-18M hits/target in a cold 30-min run, no crashes).

## Disclosure

Per CONTRIBUTING.md: developed with substantial LLM assistance (Claude); I've reviewed and verified all of it, am accountable for it, and can answer questions in review.