### PR TITLE
Use clock_gettime when POSIX monotonic clock is available

### DIFF
--- a/avahi-autoipd/main.c
+++ b/avahi-autoipd/main.c
@@ -785,7 +785,7 @@ int is_ll_address(uint32_t addr) {
 static struct timeval *elapse_time(struct timeval *tv, unsigned msec, unsigned jitter) {
     assert(tv);
 
-    gettimeofday(tv, NULL);
+    avahi_now(tv);
 
     if (msec)
         avahi_timeval_add(tv, (AvahiUsec) msec*1000);

--- a/avahi-common/simple-watch.c
+++ b/avahi-common/simple-watch.c
@@ -486,13 +486,12 @@ int avahi_simple_poll_prepare(AvahiSimplePoll *s, int timeout) {
         if (next_timeout->expiry.tv_sec == 0 &&
             next_timeout->expiry.tv_usec == 0) {
 
-            /* Just a shortcut so that we don't need to call gettimeofday() */
+            /* Just a shortcut so that we don't need to call avahi_now() */
             timeout = 0;
             goto finish;
         }
 
-        gettimeofday(&now, NULL);
-        usec = avahi_timeval_diff(&next_timeout->expiry, &now);
+        usec = avahi_timeval_diff(&next_timeout->expiry, avahi_now(&now));
 
         if (usec <= 0) {
             /* Timeout elapsed */
@@ -559,7 +558,7 @@ int avahi_simple_poll_dispatch(AvahiSimplePoll *s) {
 
         if (next_timeout->expiry.tv_sec == 0 && next_timeout->expiry.tv_usec == 0) {
 
-            /* Just a shortcut so that we don't need to call gettimeofday() */
+            /* Just a shortcut so that we don't need to call avahi_now() */
             timeout_callback(next_timeout);
             goto finish;
         }

--- a/avahi-common/timeval.c
+++ b/avahi-common/timeval.c
@@ -24,8 +24,18 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <assert.h>
+#ifdef HAVE_TIME_H
+#include <time.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 
 #include "timeval.h"
+
+#if defined(HAVE_CLOCK_GETTIME) && defined(_POSIX_MONOTONIC_CLOCK)
+#define USE_MONOTONIC 1
+#endif
 
 int avahi_timeval_compare(const struct timeval *a, const struct timeval *b) {
     assert(a);
@@ -73,20 +83,44 @@ struct timeval* avahi_timeval_add(struct timeval *a, AvahiUsec usec) {
     return a;
 }
 
+struct timeval *avahi_now(struct timeval *now) {
+    struct timeval tv;
+#if USE_MONOTONIC
+    struct timespec ts;
+#endif
+
+    assert(now);
+
+#if USE_MONOTONIC
+    /* Use a monotonic clock if possible. This prevents jumps in the system
+     * clock from messing with timers (especially jumps backward) */
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+        now->tv_sec = ts.tv_sec;
+        now->tv_usec = ts.tv_nsec / 1000;
+    } else {
+#endif
+        gettimeofday(&tv, NULL);
+        now->tv_sec = tv.tv_sec;
+        now->tv_usec = tv.tv_usec;
+#if USE_MONOTONIC
+    }
+#endif
+
+    return now;
+}
+
 AvahiUsec avahi_age(const struct timeval *a) {
     struct timeval now;
 
     assert(a);
 
-    gettimeofday(&now, NULL);
-
-    return avahi_timeval_diff(&now, a);
+    return avahi_timeval_diff(avahi_now(&now), a);
 }
 
 struct timeval *avahi_elapse_time(struct timeval *tv, unsigned msec, unsigned jitter) {
     assert(tv);
 
-    gettimeofday(tv, NULL);
+    avahi_now(tv);
 
     if (msec)
         avahi_timeval_add(tv, (AvahiUsec) msec*1000);

--- a/avahi-common/timeval.h
+++ b/avahi-common/timeval.h
@@ -41,6 +41,11 @@ AvahiUsec avahi_timeval_diff(const struct timeval *a, const struct timeval *b);
 /** Add a number of microseconds to the specified timeval structure and return it. *a is modified. */
 struct timeval* avahi_timeval_add(struct timeval *a, AvahiUsec usec);
 
+/** Get the current timestamp. This will return a monotonic clock if possible,
+ * so it should not be used if you need a timeval for display or comparison
+ * with gettimeofday(). Returns the input timeval */
+struct timeval* avahi_now(struct timeval *now);
+
 /** Return the difference between the current time and *a. Positive if *a was earlier */
 AvahiUsec avahi_age(const struct timeval *a);
 

--- a/avahi-core/cache.c
+++ b/avahi-core/cache.c
@@ -268,7 +268,7 @@ static void expire_in_one_second(AvahiCache *c, AvahiCacheEntry *e, AvahiCacheEn
     assert(e);
 
     e->state = state;
-    gettimeofday(&e->expiry, NULL);
+    avahi_now(&e->expiry);
     avahi_timeval_add(&e->expiry, 1000000); /* 1s */
     update_time_event(c, e);
 }
@@ -293,7 +293,7 @@ void avahi_cache_update(AvahiCache *c, AvahiRecord *r, int cache_flush, const Av
         AvahiCacheEntry *e = NULL, *first;
         struct timeval now;
 
-        gettimeofday(&now, NULL);
+        avahi_now(&now);
 
         /* This is an update request */
 
@@ -421,7 +421,7 @@ int avahi_cache_entry_half_ttl(AvahiCache *c, AvahiCacheEntry *e) {
     assert(c);
     assert(e);
 
-    gettimeofday(&now, NULL);
+    avahi_now(&now);
 
     age = (unsigned) (avahi_timeval_diff(&now, &e->timestamp)/1000000);
 
@@ -448,7 +448,7 @@ static void* start_poof_callback(AvahiCache *c, AvahiKey *pattern, AvahiCacheEnt
     assert(e);
     assert(a);
 
-    gettimeofday(&now, NULL);
+    avahi_now(&now);
 
     switch (e->state) {
         case AVAHI_CACHE_VALID:

--- a/avahi-core/entry.c
+++ b/avahi-core/entry.c
@@ -1041,7 +1041,7 @@ void avahi_s_entry_group_change_state(AvahiSEntryGroup *g, AvahiEntryGroupState 
         /* If the entry group is now established, remember the time
          * this happened */
 
-        gettimeofday(&g->established_at, NULL);
+        avahi_now(&g->established_at);
 
     g->state = state;
 
@@ -1121,7 +1121,7 @@ void avahi_s_entry_group_free(AvahiSEntryGroup *g) {
 static void entry_group_commit_real(AvahiSEntryGroup *g) {
     assert(g);
 
-    gettimeofday(&g->register_time, NULL);
+    avahi_now(&g->register_time);
 
     avahi_s_entry_group_change_state(g, AVAHI_ENTRY_GROUP_REGISTERING);
 
@@ -1162,7 +1162,7 @@ int avahi_s_entry_group_commit(AvahiSEntryGroup *g) {
                             AVAHI_RR_HOLDOFF_MSEC_RATE_LIMIT :
                             AVAHI_RR_HOLDOFF_MSEC));
 
-    gettimeofday(&now, NULL);
+    avahi_now(&now);
 
     if (avahi_timeval_compare(&g->register_time, &now) <= 0) {
 

--- a/avahi-core/iface.c
+++ b/avahi-core/iface.c
@@ -29,6 +29,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
+#include <avahi-common/timeval.h>
 #include <avahi-common/error.h>
 #include <avahi-common/malloc.h>
 #include <avahi-common/domain.h>
@@ -580,7 +581,7 @@ void avahi_interface_send_packet_unicast(AvahiInterface *i, AvahiDnsPacket *p, c
     if (i->monitor->server->config.ratelimit_interval > 0) {
         struct timeval now, end;
 
-        gettimeofday(&now, NULL);
+        avahi_now(&now);
 
         end = i->hardware->ratelimit_begin;
         avahi_timeval_add(&end, i->monitor->server->config.ratelimit_interval);

--- a/avahi-core/probe-sched.c
+++ b/avahi-core/probe-sched.c
@@ -124,7 +124,7 @@ static void job_mark_done(AvahiProbeScheduler *s, AvahiProbeJob *pj) {
     pj->done = 1;
 
     job_set_elapse_time(s, pj, AVAHI_PROBE_HISTORY_MSEC, 0);
-    gettimeofday(&pj->delivery, NULL);
+    avahi_now(&pj->delivery);
 }
 
 AvahiProbeScheduler *avahi_probe_scheduler_new(AvahiInterface *i) {

--- a/avahi-core/querier.c
+++ b/avahi-core/querier.c
@@ -124,7 +124,7 @@ void avahi_querier_add(AvahiInterface *i, AvahiKey *key, struct timeval *ret_cti
     q->n_used = 1;
     q->sec_delay = 1;
     q->post_id_valid = 0;
-    gettimeofday(&q->creation_time, NULL);
+    avahi_now(&q->creation_time);
 
     /* Do the initial query */
     if (avahi_interface_post_query(i, key, 0, &q->post_id))

--- a/avahi-core/query-sched.c
+++ b/avahi-core/query-sched.c
@@ -145,7 +145,7 @@ static void job_mark_done(AvahiQueryScheduler *s, AvahiQueryJob *qj) {
     qj->done = 1;
 
     job_set_elapse_time(s, qj, AVAHI_QUERY_HISTORY_MSEC, 0);
-    gettimeofday(&qj->delivery, NULL);
+    avahi_now(&qj->delivery);
 }
 
 AvahiQueryScheduler *avahi_query_scheduler_new(AvahiInterface *i) {
@@ -411,7 +411,7 @@ void avahi_query_scheduler_incoming(AvahiQueryScheduler *s, AvahiKey *key) {
         if (!(qj = job_new(s, key, 1)))
             return; /* OOM */
 
-    gettimeofday(&qj->delivery, NULL);
+    avahi_now(&qj->delivery);
     job_set_elapse_time(s, qj, AVAHI_QUERY_HISTORY_MSEC, 0);
 }
 

--- a/avahi-core/response-sched.c
+++ b/avahi-core/response-sched.c
@@ -148,7 +148,7 @@ static void job_mark_done(AvahiResponseScheduler *s, AvahiResponseJob *rj) {
 
     job_set_elapse_time(s, rj, AVAHI_RESPONSE_HISTORY_MSEC, 0);
 
-    gettimeofday(&rj->delivery, NULL);
+    avahi_now(&rj->delivery);
 }
 
 AvahiResponseScheduler *avahi_response_scheduler_new(AvahiInterface *i) {
@@ -460,7 +460,7 @@ void avahi_response_scheduler_incoming(AvahiResponseScheduler *s, AvahiRecord *r
     rj->flush_cache = flush_cache;
     rj->querier_valid = 0;
 
-    gettimeofday(&rj->delivery, NULL);
+    avahi_now(&rj->delivery);
     job_set_elapse_time(s, rj, AVAHI_RESPONSE_HISTORY_MSEC, 0);
 }
 
@@ -498,7 +498,7 @@ void avahi_response_scheduler_suppress(AvahiResponseScheduler *s, AvahiRecord *r
         rj->querier = *querier;
     }
 
-    gettimeofday(&rj->delivery, NULL);
+    avahi_now(&rj->delivery);
     job_set_elapse_time(s, rj, AVAHI_RESPONSE_SUPPRESS_MSEC, 0);
 }
 

--- a/avahi-core/timeeventq.c
+++ b/avahi-core/timeeventq.c
@@ -80,7 +80,7 @@ static void expiration_event(AVAHI_GCC_UNUSED AvahiTimeout *timeout, void *userd
     if ((e = time_event_queue_root(q))) {
         struct timeval now;
 
-        gettimeofday(&now, NULL);
+        avahi_now(&now);
 
         /* Check if expired */
         if (avahi_timeval_compare(&now, &e->expiry) >= 0) {
@@ -108,7 +108,7 @@ static void fix_expiry_time(AvahiTimeEvent *e) {
 
     return; /*** DO WE REALLY NEED THIS? ***/
 
-    gettimeofday(&now, NULL);
+    avahi_now(&now);
 
     if (avahi_timeval_compare(&now, &e->expiry) > 0)
         e->expiry = now;

--- a/avahi-core/wide-area.c
+++ b/avahi-core/wide-area.c
@@ -500,7 +500,7 @@ static void add_to_cache(AvahiWideAreaLookupEngine *e, AvahiRecord *r) {
 
     c->record = avahi_record_ref(r);
 
-    gettimeofday(&c->timestamp, NULL);
+    avahi_now(&c->timestamp);
     c->expiry = c->timestamp;
     avahi_timeval_add(&c->expiry, r->ttl * 1000000);
 

--- a/avahi-libevent/libevent-watch.c
+++ b/avahi-libevent/libevent-watch.c
@@ -25,6 +25,7 @@
 #include <event2/event.h>
 #include <event2/event_struct.h>
 
+#include <avahi-common/timeval.h>
 #include <avahi-common/llist.h>
 #include <avahi-common/malloc.h>
 #include <avahi-common/timeval.h>
@@ -185,7 +186,7 @@ timeout_add(AvahiTimeout *t, const struct timeval *tv)
 	if (!tv || ((tv->tv_sec == 0) && (tv->tv_usec == 0)))
 		evutil_timerclear(&e_tv);
 	else {
-		(void)gettimeofday(&now, NULL);
+		(void)avahi_now(&now);
 		evutil_timersub(tv, &now, &e_tv);
 	}
 
@@ -235,7 +236,7 @@ timeout_update(AvahiTimeout *t, const struct timeval *tv)
 	if (!tv)
 		return;
 
-	(void)gettimeofday(&now, NULL);
+	(void)avahi_now(&now);
 	evutil_timersub(tv, &now, &e_tv);
 
 	event_add(&t->ev, &e_tv);

--- a/configure.ac
+++ b/configure.ac
@@ -367,7 +367,7 @@ AC_FUNC_SELECT_ARGTYPES
 # whether libc's malloc does too. (Same for realloc.)
 #AC_FUNC_MALLOC
 #AC_FUNC_REALLOC
-AC_CHECK_FUNCS([gethostname memchr memmove memset mkdir select socket strchr strcspn strdup strerror strrchr strspn strstr uname setresuid setreuid setresgid setregid strcasecmp gettimeofday putenv strncasecmp strlcpy gethostbyname seteuid setegid setproctitle getprogname getrandom])
+AC_CHECK_FUNCS([clock_gettime gethostname memchr memmove memset mkdir select socket strchr strcspn strdup strerror strrchr strspn strstr uname setresuid setreuid setresgid setregid strcasecmp gettimeofday putenv strncasecmp strlcpy gethostbyname seteuid setegid setproctitle getprogname getrandom])
 AC_CHECK_HEADERS([sys/random.h])
 
 AC_FUNC_CHOWN


### PR DESCRIPTION
This is a simplified version of #96 which avoides the API breaking.

Fixes #359