### PR TITLE
core: forward NSEC records without a public struct change

### DIFF
--- a/avahi-common/defs.h
+++ b/avahi-common/defs.h
@@ -335,7 +335,8 @@ enum {
     AVAHI_DNS_TYPE_MX = 0x0F,
     AVAHI_DNS_TYPE_TXT = 0x10,
     AVAHI_DNS_TYPE_AAAA = 0x1C,
-    AVAHI_DNS_TYPE_SRV = 0x21
+    AVAHI_DNS_TYPE_SRV = 0x21,
+    AVAHI_DNS_TYPE_NSEC = 0x2F  /**< NSEC record (RFC 4034); used by mDNS per RFC 6762 */
 };
 
 /** DNS record classes, see RFC 1035 */

--- a/avahi-core/dns-test.c
+++ b/avahi-core/dns-test.c
@@ -22,6 +22,8 @@
 #endif
 
 #include <assert.h>
+#include <stddef.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -35,6 +37,36 @@
 #include "log.h"
 #include "rr-util.h"
 #include "util.h"
+
+/* Build an NSEC record with a realistic mDNS type bitmap (window block 0
+ * advertising A (type 1) and AAAA (type 28), as used in RFC 6762). The
+ * generic representation exposes no NSEC fields to set, so the record is
+ * built from its wire rdata. */
+static AvahiRecord *make_nsec(const char *owner, const char *next_domain_name) {
+    static const uint8_t bitmap[] = { 0x00, 0x04, 0x40, 0x00, 0x00, 0x08 };
+    uint8_t rdata[AVAHI_DOMAIN_NAME_MAX + sizeof(bitmap)];
+    AvahiDnsPacket np;
+    size_t n;
+    AvahiRecord *r;
+
+    np.data = rdata;
+    np.max_size = sizeof(rdata);
+    np.size = np.rindex = 0;
+    np.name_table = NULL;
+
+    avahi_dns_packet_append_name(&np, next_domain_name);
+    if (np.name_table)
+        avahi_hashmap_free(np.name_table);
+
+    n = np.size;
+    memcpy(rdata + n, bitmap, sizeof(bitmap));
+    n += sizeof(bitmap);
+
+    r = avahi_record_new_full(owner, AVAHI_DNS_CLASS_IN, AVAHI_DNS_TYPE_NSEC, AVAHI_DEFAULT_TTL);
+    assert(avahi_rdata_parse(r, rdata, n) >= 0);
+
+    return r;
+}
 
 int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     char t[AVAHI_DOMAIN_NAME_MAX], *m;
@@ -186,6 +218,195 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
 
     avahi_free(m);
     avahi_record_unref(r);
+
+    /* NSEC: isolated rdata round-trip (Next Domain Name + type bitmap) */
+    r = make_nsec("host.local", "host.local");
+
+    l = avahi_rdata_serialize(r, rdata, sizeof(rdata));
+    assert(l != (size_t) -1);
+
+    avahi_hexdump(rdata, l);
+
+    r2 = avahi_record_new(r->key, AVAHI_DEFAULT_TTL);
+    res = avahi_rdata_parse(r2, rdata, l);
+    assert(res >= 0);
+
+    assert(avahi_record_equal_no_ttl(r, r2));
+    assert(avahi_record_lexicographical_compare(r, r2) == 0);
+
+    m = avahi_record_to_string(r);
+    assert(m);
+    avahi_log_debug(">%s<", m);
+    avahi_free(m);
+
+    avahi_record_unref(r);
+    avahi_record_unref(r2);
+
+    /* NSEC: empty type bitmap. The record is just the Next Domain Name; it
+     * must round-trip and compare as smaller than a non-empty NSEC. */
+    {
+        uint8_t rd[64];
+        AvahiDnsPacket np;
+        AvahiRecord *nr, *nr2, *nonempty;
+
+        np.data = rd;
+        np.max_size = sizeof(rd);
+        np.size = np.rindex = 0;
+        np.name_table = NULL;
+        avahi_dns_packet_append_name(&np, "empty.local");
+        if (np.name_table)
+            avahi_hashmap_free(np.name_table);
+
+        nr = avahi_record_new_full("empty.local", AVAHI_DNS_CLASS_IN, AVAHI_DNS_TYPE_NSEC, AVAHI_DEFAULT_TTL);
+        assert(avahi_rdata_parse(nr, rd, np.size) >= 0);
+
+        l = avahi_rdata_serialize(nr, rdata, sizeof(rdata));
+        assert(l == np.size && memcmp(rdata, rd, np.size) == 0);
+
+        nr2 = avahi_record_copy(nr);
+        assert(avahi_record_equal_no_ttl(nr, nr2));
+        assert(avahi_record_lexicographical_compare(nr, nr2) == 0);
+
+        nonempty = make_nsec("empty.local", "empty.local");
+        assert(avahi_record_lexicographical_compare(nr, nonempty) < 0);
+        assert(avahi_record_lexicographical_compare(nonempty, nr) > 0);
+
+        avahi_record_unref(nr);
+        avahi_record_unref(nr2);
+        avahi_record_unref(nonempty);
+    }
+
+    /* NSEC: compression regression test.
+     *
+     * In mDNS the NSEC Next Domain Name is usually the record's own owner
+     * name and is therefore name-compressed on the wire (RFC 6762 18.14).
+     * Avahi used to treat NSEC as opaque rdata and froze the original
+     * packet's compression pointer into the blob, then re-emitted those
+     * exact bytes when reflecting the record into a new packet -- where the
+     * same offset points at unrelated data. This test reflects an NSEC
+     * record through two packets with DIFFERENT layouts and checks the Next
+     * Domain Name survives intact. */
+    {
+        AvahiRecord *nsec, *prefix, *parsed, *skip;
+        AvahiDnsPacket *p1, *p2;
+
+        nsec = make_nsec("host.local", "host.local");
+
+        /* Packet 1: the owner name is appended first, so append_record
+         * compresses the Next Domain Name down to a pointer back to it. */
+        p1 = avahi_dns_packet_new(0);
+        resp = avahi_dns_packet_append_record(p1, nsec, 0, 0);
+        assert(resp);
+
+        parsed = avahi_dns_packet_consume_record(p1, NULL);
+        assert(parsed);
+        assert(avahi_record_equal_no_ttl(nsec, parsed));
+
+        /* Packet 2: prepend an unrelated record so "host.local" lands at a
+         * different offset, then reflect the parsed NSEC into it. With the
+         * old code the frozen pointer would now decode to garbage. */
+        p2 = avahi_dns_packet_new(0);
+
+        prefix = avahi_record_new_full("a.much.longer.unrelated.name.local", AVAHI_DNS_CLASS_IN, AVAHI_DNS_TYPE_PTR, AVAHI_DEFAULT_TTL);
+        prefix->data.ptr.name = avahi_strdup("target.local");
+
+        resp = avahi_dns_packet_append_record(p2, prefix, 0, 0);
+        assert(resp);
+        resp = avahi_dns_packet_append_record(p2, parsed, 0, 0);
+        assert(resp);
+
+        avahi_record_unref(parsed);
+
+        skip = avahi_dns_packet_consume_record(p2, NULL);
+        assert(skip);
+        avahi_record_unref(skip);
+
+        parsed = avahi_dns_packet_consume_record(p2, NULL);
+        assert(parsed);
+        assert(avahi_record_equal_no_ttl(nsec, parsed));
+
+        avahi_record_unref(parsed);
+        avahi_record_unref(prefix);
+        avahi_record_unref(nsec);
+        avahi_dns_packet_free(p1);
+        avahi_dns_packet_free(p2);
+    }
+
+    /* NSEC: a record whose Next Domain Name arrives compressed but whose
+     * bitmap is so large that the name + bitmap would overflow the 16-bit
+     * rdata limit once the name is written back uncompressed must be
+     * rejected at parse time. On the wire the name is a 2-byte pointer, so
+     * the record fits in rdlength; only after decompression does it
+     * overflow, and a record we accept must always be re-serializable. */
+    {
+        static const uint8_t owner[] = { 0x04,'h','o','s','t', 0x05,'l','o','c','a','l', 0x00 };
+        size_t bitmap_size = AVAHI_DNS_RDATA_MAX - 5;
+        size_t rdlen = 2 + bitmap_size;
+        size_t total = AVAHI_DNS_PACKET_HEADER_SIZE + sizeof(owner) + 10 + rdlen;
+        uint8_t *pkt;
+        size_t off;
+        AvahiDnsPacket *p1;
+        AvahiRecord *parsed;
+
+        pkt = avahi_malloc0(total);
+
+        off = AVAHI_DNS_PACKET_HEADER_SIZE;
+        memcpy(pkt + off, owner, sizeof(owner)); off += sizeof(owner);
+        pkt[off++] = 0x00; pkt[off++] = 0x2f;                 /* type NSEC */
+        pkt[off++] = 0x00; pkt[off++] = 0x01;                 /* class IN */
+        pkt[off++] = 0; pkt[off++] = 0; pkt[off++] = 0x11; pkt[off++] = 0x94; /* ttl */
+        pkt[off++] = (uint8_t) (rdlen >> 8); pkt[off++] = (uint8_t) rdlen;    /* rdlength */
+        pkt[off++] = 0xc0; pkt[off++] = 0x0c;                 /* Next Domain Name -> owner @12 */
+        /* remaining bitmap_size bytes stay zero */
+
+        p1 = avahi_dns_packet_new(0);
+        memcpy(AVAHI_DNS_PACKET_DATA(p1), pkt, total);
+        p1->size = total;
+
+        parsed = avahi_dns_packet_consume_record(p1, NULL);
+        assert(!parsed);
+
+        avahi_dns_packet_free(p1);
+        avahi_free(pkt);
+    }
+
+    /* NSEC: a Next Domain Name we can parse but cannot re-escape -- here a
+     * label holding a NUL byte, which avahi_unescape_label() rejects -- must
+     * be refused at parse time. The name lives in the generic blob, so it is
+     * not covered by avahi_record_is_valid() the way PTR/SRV names are;
+     * without an explicit check the record would parse yet fail to
+     * re-serialize when reflected. */
+    {
+        static const uint8_t owner[] = { 0x04,'h','o','s','t', 0x05,'l','o','c','a','l', 0x00 };
+        /* Next Domain Name = one label holding a single 0x00 byte (01 00 00),
+         * followed by a small type bitmap. */
+        static const uint8_t rd[] = { 0x01, 0x00, 0x00, 0x00, 0x04, 0x40, 0x00, 0x00, 0x08 };
+        size_t total = AVAHI_DNS_PACKET_HEADER_SIZE + sizeof(owner) + 10 + sizeof(rd);
+        uint8_t *pkt;
+        size_t off;
+        AvahiDnsPacket *p1;
+        AvahiRecord *parsed;
+
+        pkt = avahi_malloc0(total);
+
+        off = AVAHI_DNS_PACKET_HEADER_SIZE;
+        memcpy(pkt + off, owner, sizeof(owner)); off += sizeof(owner);
+        pkt[off++] = 0x00; pkt[off++] = 0x2f;                 /* type NSEC */
+        pkt[off++] = 0x00; pkt[off++] = 0x01;                 /* class IN */
+        pkt[off++] = 0; pkt[off++] = 0; pkt[off++] = 0x11; pkt[off++] = 0x94; /* ttl */
+        pkt[off++] = 0x00; pkt[off++] = (uint8_t) sizeof(rd); /* rdlength */
+        memcpy(pkt + off, rd, sizeof(rd)); off += sizeof(rd);
+
+        p1 = avahi_dns_packet_new(0);
+        memcpy(AVAHI_DNS_PACKET_DATA(p1), pkt, total);
+        p1->size = total;
+
+        parsed = avahi_dns_packet_consume_record(p1, NULL);
+        assert(!parsed);
+
+        avahi_dns_packet_free(p1);
+        avahi_free(pkt);
+    }
 
     return 0;
 }

--- a/avahi-core/dns.c
+++ b/avahi-core/dns.c
@@ -546,7 +546,6 @@ static int parse_rdata(AvahiDnsPacket *p, AvahiRecord *r, uint16_t rdlength) {
 
             break;
 
-
         case AVAHI_DNS_TYPE_SRV:
 
             if (avahi_dns_packet_consume_uint16(p, &r->data.srv.priority) < 0 ||
@@ -606,6 +605,57 @@ static int parse_rdata(AvahiDnsPacket *p, AvahiRecord *r, uint16_t rdlength) {
                 return -1;
 
             break;
+
+        case AVAHI_DNS_TYPE_NSEC: {
+
+            /* NSEC rdata is a domain name (which may be name-compressed on
+             * the wire, RFC 6762 18.14) followed by a raw type bitmap. Since
+             * we only reflect this record, we avoid polluting the public
+             * AvahiRecord and instead store the decompressed name as a string
+             * immediately followed by the bitmap in the generic blob. That
+             * keeps the record forwardable with no stale compression pointers;
+             * append_rdata() re-compresses the name for its own packet. */
+
+            const uint8_t *bitmap;
+            size_t consumed, namelen, bitmap_size;
+
+            if (avahi_dns_packet_consume_name(p, buf, sizeof(buf)) < 0)
+                return -1;
+
+            /* The name lives in the generic blob, so avahi_record_is_valid()
+             * does not cover it the way it does PTR/SRV names. Validate it
+             * here: a name we accept but cannot re-escape (e.g. a label with a
+             * NUL byte) would parse yet fail to re-serialize when reflected. */
+            if (!avahi_is_valid_domain_name(buf))
+                return -1;
+
+            /* The bitmap is whatever rdata is left after its on-wire encoding. */
+            bitmap = avahi_dns_packet_get_rptr(p);
+            consumed = bitmap - (const uint8_t*) start;
+            if (consumed > rdlength)
+                return -1;
+            bitmap_size = rdlength - consumed;
+
+            /* A compressed name decompresses to a larger form; reject anything
+             * that could no longer be re-serialized within the 16-bit rdata
+             * limit (an uncompressed name is at most strlen()+2 bytes). */
+            if (strlen(buf) + 2 + bitmap_size > AVAHI_DNS_RDATA_MAX)
+                return -1;
+
+            namelen = strlen(buf) + 1;
+            r->data.generic.size = (uint16_t) (namelen + bitmap_size);
+            if (!(r->data.generic.data = avahi_malloc(r->data.generic.size)))
+                return -1;
+
+            memcpy(r->data.generic.data, buf, namelen);
+            if (bitmap_size > 0)
+                memcpy((uint8_t*) r->data.generic.data + namelen, bitmap, bitmap_size);
+
+            if (avahi_dns_packet_skip(p, bitmap_size) < 0)
+                return -1;
+
+            break;
+        }
 
         default:
 
@@ -780,6 +830,25 @@ static int append_rdata(AvahiDnsPacket *p, AvahiRecord *r) {
                 return -1;
 
             break;
+
+        case AVAHI_DNS_TYPE_NSEC: {
+
+            /* The generic blob holds the Next Domain Name as a string
+             * followed by the type bitmap. Re-compress the name for this
+             * packet (RFC 6762 18.14), then append the bitmap verbatim. */
+
+            const char *name = r->data.generic.data;
+            size_t namelen = strlen(name) + 1;
+
+            if (!avahi_dns_packet_append_name(p, name))
+                return -1;
+
+            if (r->data.generic.size > namelen)
+                if (!avahi_dns_packet_append_bytes(p, (uint8_t*) r->data.generic.data + namelen, r->data.generic.size - namelen))
+                    return -1;
+
+            break;
+        }
 
         default:
 

--- a/avahi-core/rr.c
+++ b/avahi-core/rr.c
@@ -219,6 +219,8 @@ const char *avahi_dns_type_to_string(uint16_t type) {
             return "SOA";
         case AVAHI_DNS_TYPE_NS:
             return "NS";
+        case AVAHI_DNS_TYPE_NSEC:
+            return "NSEC";
         default:
             return NULL;
     }


### PR DESCRIPTION
An alternative fix for https://github.com/avahi/avahi/issues/379 without committing to a public interface change as #934 did.

## Summary
Avahi parses NSEC (type 47) as opaque rdata. But an NSEC record starts with a domain name (the Next Domain Name) that mDNS name-compresses (RFC 6762 §18.14), so storing it as raw bytes freezes the source packet's compression pointer into the blob. On reflection that pointer is re-emitted at a different offset, where it points at unrelated data, the record decodes to garbage and Wireshark flags the reflected packet as malformed.

Rather than add a dedicated NSEC member to the public AvahiRecord union (rr.h is an installed header, so that would be an ABI commitment before NSEC is supported properly), store the decompressed Next Domain Name as a string followed by the type bitmap in the existing generic blob. append_rdata() re-compresses the name for its destination packet. The record is therefore always forwardable, with no stale pointers, and no public layout is committed.

I stumbled upon https://github.com/avahi/avahi/issues/379 as I noticed Avahi's reflected mDNS traffic was being flagged as malformed by Wireshark when I was investigating why my Brother printer wasn't being discovered correctly. I can confirm that this PR fixes both the printer discovery issue and Wireshark's malformed check.

## Tests
avahi-core/dns-test.c adds: rdata round-trip, empty bitmap, a compression regression, and oversize rejection. Clean under -Wall -Wextra -Werror; passes under ASan/UBSan.

No fuzzing changes needed as a coverage build confirms the existing fuzz-consume-record/fuzz-packet targets reach the new code naturally (~16-18M hits/target in a cold 30-min run, no crashes).

## Disclosure
Per CONTRIBUTING.md: developed with substantial LLM assistance (Claude); I've reviewed and verified all of it, am accountable for it, and can answer questions in review.