### PR TITLE
common: make sure valid domain names can be normalized

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -329,6 +329,9 @@ if [[ "$WITH_DBUS" == true ]]; then
     gdbus call --system --dest org.freedesktop.Avahi --object-path / --method org.freedesktop.Avahi.Server2.ResolveService \
         -- -1 0 test-notifications _qotd._tcp local -1 0 |
         grep -F '[byte 0x6b, 0x31, 0x3d, 0x76, 0x31], [0x6b, 0x32, 0x3d, 0x76, 0x32], [0x6b, 0x33, 0x3d, 0x76, 0x33]'
+
+    l=$(perl -e 'print(join(".", ("["x63)x15))')
+    should_fail dbus_call RecordBrowserNew -1 -1 "$l" 0 0 0
 fi
 
 check_rlimit_nofile

--- a/avahi-common/domain-test.c
+++ b/avahi-common/domain-test.c
@@ -121,6 +121,15 @@ int main(AVAHI_GCC_UNUSED int argc, AVAHI_GCC_UNUSED char *argv[]) {
     assert(avahi_is_valid_domain_name("."));
     assert(avahi_is_valid_domain_name(""));
 
+    res = avahi_is_valid_domain_name(
+        "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[."
+        "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[."
+        "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[."
+        "[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[."
+        "["
+    );
+    assert(!res);
+
     assert(avahi_normalize_name(".", t, sizeof(t)));
     assert(avahi_normalize_name("", t, sizeof(t)));
 

--- a/avahi-common/domain.c
+++ b/avahi-common/domain.c
@@ -369,9 +369,13 @@ int avahi_is_valid_service_subtype(const char *t) {
 
 int avahi_is_valid_domain_name(const char *t) {
     int is_first = 1;
+    char normalized[AVAHI_DOMAIN_NAME_MAX];
     assert(t);
 
     if (strlen(t) >= AVAHI_DOMAIN_NAME_MAX)
+        return 0;
+
+    if (!(avahi_normalize_name(t, normalized, sizeof(normalized))))
         return 0;
 
     do {

--- a/fuzz/fuzz-domain.c
+++ b/fuzz/fuzz-domain.c
@@ -31,6 +31,7 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     char *s = NULL, *t = NULL;
+    int r;
 
     if(!(s = avahi_malloc(size+1)))
         return 0;
@@ -42,13 +43,22 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     nalloc_start(data, size);
 #endif
 
+    if (avahi_is_valid_domain_name(s)) {
+        t = avahi_normalize_name_strdup(s);
+#ifndef HAVE_NALLOCFUZZ
+        assert(t);
+        r = avahi_domain_equal(s, t);
+        assert(r);
+#endif
+        avahi_free(t);
+    }
+
     if ((t = avahi_normalize_name_strdup(s)))
         assert(avahi_domain_equal(s, t));
 
     avahi_is_valid_service_type_generic(s);
     avahi_is_valid_service_type_strict(s);
     avahi_is_valid_service_subtype(s);
-    avahi_is_valid_domain_name(s);
     avahi_is_valid_service_name(s);
     avahi_is_valid_host_name(s);
     avahi_is_valid_fqdn(s);


### PR DESCRIPTION
It fixes a bug where it was possible for unprivileged local users to
crash avahi-daemon via D-Bus by calling the RecordBrowserNew method with
bogus domain names. For example when the following commands were run
```
l=$(perl -e 'print(join(".", ("["x63)x15))')
busctl call org.freedesktop.Avahi / org.freedesktop.Avahi.Server RecordBrowserNew "iisqqu" -- -1 -1 "$l" 0 0 0
```
avahi-daemon crashed with
```
avahi-daemon: dbus-protocol.c:984: dbus_prepare_record_browser_object: Assertion `key' failed.
==2424==
==2424== Process terminating with default action of signal 6 (SIGABRT)
==2424==    at 0x4B31DCC: __pthread_kill_implementation (in /usr/lib64/libc.so.6)
==2424==    by 0x4AD6F8D: raise (in /usr/lib64/libc.so.6)
==2424==    by 0x4ABE7B2: abort (in /usr/lib64/libc.so.6)
==2424==    by 0x4ABF803: __libc_message_impl.cold (in /usr/lib64/libc.so.6)
==2424==    by 0x4ACEE44: __assert_fail (in /usr/lib64/libc.so.6)
==2424==    by 0x4002FB8: dbus_prepare_record_browser_object.cold (dbus-protocol.c:984)
==2424==    by 0x400E4E9: dbus_select_browser.isra.0 (dbus-protocol.c:1119)
==2424==    by 0x400FCA0: msg_server_impl (dbus-protocol.c:1185)
==2424==    by 0x4A75DA3: dbus_connection_dispatch (in /usr/lib64/libdbus-1.so.3.38.3)
==2424==    by 0x4014122: dispatch_timeout_callback.lto_priv.0 (dbus-watch-glue.c:105)
==2424==    by 0x489CB4F: avahi_simple_poll_dispatch (in /usr/lib64/libavahi-common.so.3.5.4)
==2424==    by 0x4004EF7: run_server (main.c:1279)
==2424==    by 0x4004EF7: main (main.c:1708)
```

The unit test makes sure the specific domain name is rejected, the fuzz
target makes sure that the invariant holds in general and the
integration test makes sure that it all actually works via D-Bus without
crashing anywhere.

https://github.com/avahi/avahi/security/advisories/GHSA-4v6h-9g73-wm5j