### PR TITLE
tree-wide: cast chars to unsigned chars before passing them to ctype functions

### DIFF
--- a/avahi-common/alternative.c
+++ b/avahi-common/alternative.c
@@ -69,7 +69,7 @@ char *avahi_alternative_host_name(const char *s) {
         e++;
 
         for (p = e; *p; p++)
-            if (!isdigit(*p)) {
+            if (!isdigit((unsigned char)*p)) {
                 e = NULL;
                 break;
             }
@@ -151,7 +151,7 @@ char *avahi_alternative_service_name(const char *s) {
             e = n + 2;
 
         for (p = e; *p; p++)
-            if (!isdigit(*p)) {
+            if (!isdigit((unsigned char)*p)) {
                 e = NULL;
                 break;
             }

--- a/avahi-common/domain.c
+++ b/avahi-common/domain.c
@@ -73,12 +73,12 @@ char *avahi_unescape_label(const char **name, char *dest, size_t size) {
                 /* Escaped backslash or dot */
                 *(d++) = *((*name) ++);
                 i++;
-            } else if (isdigit(**name)) {
+            } else if (isdigit((unsigned char)**name)) {
                 int n;
 
                 /* Escaped literal ASCII character */
 
-                if (!isdigit(*(*name+1)) || !isdigit(*(*name+2)))
+                if (!isdigit((unsigned char)*(*name+1)) || !isdigit((unsigned char)*(*name+2)))
                     return NULL;
 
                 n = ((uint8_t) (**name - '0') * 100) + ((uint8_t) (*(*name+1) - '0') * 10) + ((uint8_t) (*(*name +2) - '0'));
@@ -436,7 +436,7 @@ unsigned avahi_domain_hash(const char *s) {
         assert(r);
 
         for (p = c; *p; p++)
-            hash = 31 * hash + tolower(*p);
+            hash = 31 * hash + tolower((unsigned char)*p);
     }
 
     return hash;

--- a/avahi-core/util.c
+++ b/avahi-core/util.c
@@ -104,7 +104,7 @@ char *avahi_strup(char *s) {
     assert(s);
 
     for (c = s; *c; c++)
-        *c = (char) toupper(*c);
+        *c = (char) toupper((unsigned char)*c);
 
     return s;
 }
@@ -114,7 +114,7 @@ char *avahi_strdown(char *s) {
     assert(s);
 
     for (c = s; *c; c++)
-        *c = (char) tolower(*c);
+        *c = (char) tolower((unsigned char)*c);
 
     return s;
 }

--- a/avahi-daemon/ini-file-parser.c
+++ b/avahi-daemon/ini-file-parser.c
@@ -162,10 +162,10 @@ char** avahi_split_csv(const char *t) {
         const char *c;
 
         /* Ignore leading blanks */
-        for (c = t, n = l; isblank(*c); c++, n--);
+        for (c = t, n = l; isblank((unsigned char)*c); c++, n--);
 
         /* Ignore trailing blanks */
-        for (; n > 0 && isblank(c[n-1]); n--);
+        for (; n > 0 && isblank((unsigned char)c[n-1]); n--);
 
         *(i++) = avahi_strndup(c, n);
 

--- a/avahi-utils/avahi-browse.c
+++ b/avahi-utils/avahi-browse.c
@@ -144,7 +144,7 @@ static char *make_printable(const char *from, char *to) {
     char *t;
 
     for (f = from, t = to; *f; f++, t++)
-        *t = isprint(*f) ? *f : '_';
+        *t = isprint((unsigned char)*f) ? *f : '_';
 
     *t = 0;
 


### PR DESCRIPTION
The standards require that the argument for these functions is either EOF or a value that is representable in the type unsigned char; otherwise, the behavior is undefined. If the argument is of type char, it must be cast to unsigned char.

On NetBSD on architectures like x86_64 where char is signed with https://github.com/NetBSD/src/commit/f1ab872339bbbcd73177f26d512a7d0dcff11ba5 included (where guard pages were put before the C ctype/tolower/toupper tables and attempts to to use the ctype(3) functions on invalid inputs reliably crash with SIGSEGV) it was possible to crash avahi-daemon by sending packets with names containing bytes >= 128.

For example with scapy it was possible to send the following packet:
```
send(IP(dst='224.0.0.251%iface')/UDP(sport=5353,dport=5353)/DNS(qr=1,qd=[],an=[DNSRR(rrname='\xd0\xb8.local',type='A',rdata='192.168.1.1',ttl=120)]))
```
as soon as avahi-daemon received that packet it went down with
```
Program received signal SIGSEGV, Segmentation fault.
0x00007c0001d279ba in avahi_domain_hash (s=0x7c0001736091 "local") at domain.c:435
435	            hash = 31 * hash + tolower(*p);
(gdb) bt
 #0  0x00007c0001d279ba in avahi_domain_hash (s=0x7c0001736091 "local") at domain.c:435
 #1  0x00007c0001d07076 in avahi_key_hash (k=0x7c00017360c0) at rr.c:362
 #2  0x00007c0001d09e8e in entry_get (m=0x7c000173e000, key=0x7c00017360c0) at hashmap.c:59
 #3  0x00007c0001d0a411 in avahi_hashmap_lookup (m=0x7c000173e000, key=0x7c00017360c0) at hashmap.c:119
 #4  0x00007c0001ce404a in handle_conflict (s=0x7c000175f500, i=0x7c0001765320, record=0x7c000179b950, unique=0) at server.c:251
 #5  0x00007c0001ce5749 in handle_response_packet (s=0x7c000175f500, p=0x7c00016f5340, i=0x7c0001765320, a=0x7f7ffff05f40, from_local_iface=0) at server.c:716
 #6  0x00007c0001ce6ade in dispatch_packet (s=0x7c000175f500, p=0x7c00016f5340, src_address=0x7f7ffff05f40, port=5353, dst_address=0x7f7ffff05f20, iface=2,
    ttl=64) at server.c:1032
 #7  0x00007c0001ce6ec0 in mcast_socket_event (w=0x7c0001764540, fd=12, events=AVAHI_WATCH_IN, userdata=0x7c000175f500) at server.c:1093
 #8  0x00007c0001d2a21f in avahi_simple_poll_dispatch (s=0x7c0001765000) at simple-watch.c:585
 #9  0x00007c0001d2a2a6 in avahi_simple_poll_iterate (s=0x7c0001765000, timeout=-1) at simple-watch.c:605
 #10 0x000000000040a077 in run_server (c=0x427ee0 <config>) at main.c:1279
 #11 0x000000000040ac63 in main (argc=3, argv=0x7f7ffff060a8) at main.c:1708
```

https://github.com/avahi/avahi/security/advisories/GHSA-8pmv-23p5-92mw