### PR TITLE
core: always create new lookups and let queriers coalesce them

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -295,7 +295,7 @@ fi
 run ./avahi-core/avahi-test
 run ./avahi-core/querier-test
 
-for test_case in self_loop retransmit_cname one_normal one_loop two_normal two_loop two_loop_inner two_loop_inner2 three_normal three_loop diamond cname_answer_diamond cname_answer; do
+for test_case in self_loop retransmit_cname one_normal one_loop two_normal two_loop two_loop_inner two_loop_inner2 three_normal three_loop diamond both_directions cname_answer_diamond cname_answer; do
     run ./avahi-core/cname-test $test_case
 done
 

--- a/avahi-core/browse.c
+++ b/avahi-core/browse.c
@@ -155,30 +155,6 @@ static AvahiSRBLookup* lookup_ref(AvahiSRBLookup *l) {
     return l;
 }
 
-static AvahiSRBLookup *lookup_find(
-    AvahiSRecordBrowser *b,
-    AvahiIfIndex interface,
-    AvahiProtocol protocol,
-    AvahiLookupFlags flags,
-    AvahiKey *key) {
-
-    AvahiSRBLookup *l;
-
-    assert(b);
-
-    for (l = b->lookups; l; l = l->lookups_next) {
-
-        if ((l->interface == AVAHI_IF_UNSPEC || l->interface == interface) &&
-            (l->interface == AVAHI_PROTO_UNSPEC || l->protocol == protocol) &&
-            l->flags == flags &&
-            avahi_key_equal(l->key, key))
-
-            return l;
-    }
-
-    return NULL;
-}
-
 static void browser_cancel(AvahiSRecordBrowser *b) {
     assert(b);
 
@@ -319,10 +295,7 @@ static int lookup_start(AvahiSRBLookup *l) {
     assert(l);
 
     assert(!(l->flags & AVAHI_LOOKUP_USE_WIDE_AREA) != !(l->flags & AVAHI_LOOKUP_USE_MULTICAST));
-    if (l->wide_area || l->multicast) {
-        /* Avoid starting a duplicate lookup */
-        return 0;
-    }
+    assert(!l->wide_area && !l->multicast);
 
     if (l->flags & AVAHI_LOOKUP_USE_WIDE_AREA) {
 
@@ -364,9 +337,6 @@ static AvahiSRBLookup* lookup_add(AvahiSRecordBrowser *b, AvahiIfIndex interface
     assert(b);
     assert(!b->dead);
 
-    if ((l = lookup_find(b, interface, protocol, flags, key)))
-        return lookup_ref(l);
-
     if (!(l = lookup_new(b, interface, protocol, flags, key)))
         return NULL;
 
@@ -400,40 +370,6 @@ static int lookup_go(AvahiSRBLookup *l) {
     return n;
 }
 
-static int lookup_exists_in_path(AvahiSRBLookup* lookup, AvahiSRBLookup* from, AvahiSRBLookup* to) {
-    AvahiRList* rl;
-    if (from == to)
-        return 0;
-    for (rl = from->cname_lookups; rl; rl = rl->rlist_next) {
-        int r = lookup_exists_in_path(lookup, rl->data, to);
-        if (r == 1) {
-            /* loop detected, propagate result */
-            return r;
-        } else if (r == 0) {
-            /* is loop detected? */
-            return lookup == from;
-        } else {
-	        /* `to` not found, continue */
-            continue;
-        }
-    }
-    /* no path found */
-    return -1;
-}
-
-static int cname_would_create_loop(AvahiSRBLookup* l, AvahiSRBLookup* n) {
-    int ret;
-    if (l == n)
-        /* Loop to self */
-        return 1;
-
-    ret = lookup_exists_in_path(n, l->record_browser->root_lookup, l);
-
-    /* Path to n always exists */
-    assert(ret != -1);
-    return ret;
-}
-
 static void lookup_handle_cname(AvahiSRBLookup *l, AvahiIfIndex interface, AvahiProtocol protocol, AvahiLookupFlags flags, AvahiRecord *r) {
     AvahiKey *k;
     AvahiSRBLookup *n;
@@ -450,12 +386,6 @@ static void lookup_handle_cname(AvahiSRBLookup *l, AvahiIfIndex interface, Avahi
 
     if (!n) {
         avahi_log_debug(__FILE__": Failed to create SRBLookup.");
-        return;
-    }
-
-    if (cname_would_create_loop(l, n)) {
-        /* CNAME loops are not allowed */
-        lookup_unref(n);
         return;
     }
 

--- a/avahi-core/cname-test.c
+++ b/avahi-core/cname-test.c
@@ -143,6 +143,13 @@ static void diamond(void) {
     avahi_test_add_cname("Z.local", "A.local");
 }
 
+static void both_directions(void) {
+    avahi_test_add_cname("X.local", "Z.local");
+    avahi_test_add_cname("X.local", "A.local");
+    avahi_test_add_cname("Z.local", "A.local");
+    avahi_test_add_cname("A.local", "Z.local");
+}
+
 static void cname_answer_diamond(void) {
     avahi_test_add_cname("X.local", "Y.local");
     avahi_test_add_cname("X.local", "Z.local");
@@ -216,13 +223,14 @@ static void avahi_test_initialize(char *test_case) {
     CHECK_TEST_CASE("three_normal", three_normal);
     CHECK_TEST_CASE("three_loop", three_loop);
     CHECK_TEST_CASE("diamond", diamond);
+    CHECK_TEST_CASE("both_directions", both_directions);
     CHECK_TEST_CASE("cname_answer_diamond", cname_answer_diamond);
     CHECK_TEST_CASE("cname_answer", cname_answer);
 
     assert(avahi_test_case_function);
 }
 
-int main(int argc, char *argv[]) {
+static void run(AvahiLookupFlags flags) {
     int error;
     struct timeval tv;
 
@@ -230,17 +238,11 @@ int main(int argc, char *argv[]) {
     AvahiServerConfig config;
     AvahiSimplePoll *simple_poll;
 
-    if (argc < 2) {
-        printf("Usage: %s test_name", argv[0]);
-        return 1;
-    }
-
-    avahi_test_initialize(argv[1]);
-
     simple_poll = avahi_simple_poll_new();
     poll_api = avahi_simple_poll_get(simple_poll);
 
     avahi_server_config_init(&config);
+    config.enable_wide_area = 1;
     server = avahi_server_new(poll_api, &config, server_callback, NULL, &error);
     avahi_server_config_free(&config);
 
@@ -248,7 +250,7 @@ int main(int argc, char *argv[]) {
     avahi_cache_flush(cache);
 
     hnr = avahi_s_host_name_resolver_prepare(server, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, "X.local", AVAHI_PROTO_UNSPEC,
-                                             AVAHI_LOOKUP_USE_MULTICAST, hnr_callback, NULL);
+                                             flags, hnr_callback, NULL);
     avahi_s_host_name_resolver_start(hnr);
 
     avahi_elapse_time(&tv, 1000 * 5, 0);
@@ -266,6 +268,17 @@ int main(int argc, char *argv[]) {
     if (simple_poll) {
         avahi_simple_poll_free(simple_poll);
     }
+}
 
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        printf("Usage: %s test_name", argv[0]);
+        return 1;
+    }
+
+    avahi_test_initialize(argv[1]);
+    run(0);
+    run(AVAHI_LOOKUP_USE_MULTICAST);
+    run(AVAHI_LOOKUP_USE_WIDE_AREA);
     return 0;
 }


### PR DESCRIPTION
It drops the lookup_find logic. It has never actually worked due to the
way the flags were compared but other than that it was a constant source
of crashes, segfaults, memory corruptions and so on.

It fixes a bug where it was possible to trigger a use-after-free by
sending CNAME RRs. For example with scapy it was possible to send the
following packet:
```
send(
    IP(dst='224.0.0.251%iface-name')/
    UDP(sport=5353,dport=5353)/
    DNS(qd=[],qr=1,an=[
        DNSRR(rrname='x.local', type='CNAME', ttl=10, rdata='z.local'),
        DNSRR(rrname='x.local', type='CNAME', ttl=10, rdata='a.local'),
        DNSRR(rrname='z.local', type='CNAME', ttl=10, rdata='a.local'),
        DNSRR(rrname='a.local', type='CNAME', ttl=10, rdata='z.local'),
    ])
)
```
to trigger a use-afer-free in avahi-daemon (as long as at least one `x.local`
browser was either active or started before those RRs expire).
```
=================================================================
==196530==ERROR: AddressSanitizer: heap-use-after-free on address 0x7bcf557e07e0 at pc 0x7f1f56a94f70 bp 0x7ffd8d385ae0 sp 0x7ffd8d385ad8
READ of size 4 at 0x7bcf557e07e0 thread T0
    #0 0x7f1f56a94f6f in lookup_multicast_callback /home/vagrant/avahi/avahi-core/browse.c:266:12
    #1 0x7f1f56af5aae in avahi_multicast_lookup_engine_notify /home/vagrant/avahi/avahi-core/multicast-lookup.c:317:21
    #2 0x7f1f56a5a1b0 in remove_entry /home/vagrant/avahi/avahi-core/cache.c:57:5
    #3 0x7f1f56a5f352 in elapse_func /home/vagrant/avahi/avahi-core/cache.c:183:13
    #4 0x7f1f56a03a64 in expiration_event /home/vagrant/avahi/avahi-core/timeeventq.c:94:13
    #5 0x7f1f56e58d21 in timeout_callback /home/vagrant/avahi/avahi-common/simple-watch.c:447:5
    #6 0x7f1f56e57c2d in avahi_simple_poll_dispatch /home/vagrant/avahi/avahi-common/simple-watch.c:570:13
    #7 0x7f1f56e58d8a in avahi_simple_poll_iterate /home/vagrant/avahi/avahi-common/simple-watch.c:605:14
    #8 0x0000004fb92c in run_server /home/vagrant/avahi/avahi-daemon/main.c:1279:18
    #9 0x0000004ecd94 in main /home/vagrant/avahi/avahi-daemon/main.c:1708:13
    #10 0x7f1f566b3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #11 0x7f1f566b3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #12 0x000000401444 in _start (/home/vagrant/avahi/avahi-daemon/.libs/avahi-daemon+0x401444) (BuildId: 249ee71ab5864b3df21944cb6fc56865f4f2800c)

0x7bcf557e07e0 is located 16 bytes inside of 104-byte region [0x7bcf557e07d0,0x7bcf557e0838)
freed by thread T0 here:
    #0 0x0000004a725a in free (/home/vagrant/avahi/avahi-daemon/.libs/avahi-daemon+0x4a725a) (BuildId: 249ee71ab5864b3df21944cb6fc56865f4f2800c)
    #1 0x7f1f56e3b4ba in avahi_free /home/vagrant/avahi/avahi-common/malloc.c:138:9
    #2 0x7f1f56a8f182 in avahi_s_record_browser_destroy /home/vagrant/avahi/avahi-core/browse.c:648:5
    #3 0x7f1f56a8f4e5 in avahi_browser_cleanup /home/vagrant/avahi/avahi-core/browse.c:664:17
    #4 0x7f1f56a3d8a5 in avahi_cleanup_dead_entries /home/vagrant/avahi/avahi-core/entry.c:143:9
    #5 0x7f1f56a2e341 in mcast_socket_event /home/vagrant/avahi/avahi-core/server.c:1099:9
    #6 0x7f1f56e587d9 in avahi_simple_poll_dispatch /home/vagrant/avahi/avahi-common/simple-watch.c:585:13
    #7 0x7f1f56e58d8a in avahi_simple_poll_iterate /home/vagrant/avahi/avahi-common/simple-watch.c:605:14
    #8 0x0000004fb92c in run_server /home/vagrant/avahi/avahi-daemon/main.c:1279:18
    #9 0x0000004ecd94 in main /home/vagrant/avahi/avahi-daemon/main.c:1708:13
    #10 0x7f1f566b3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #11 0x7f1f566b3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #12 0x000000401444 in _start (/home/vagrant/avahi/avahi-daemon/.libs/avahi-daemon+0x401444) (BuildId: 249ee71ab5864b3df21944cb6fc56865f4f2800c)

previously allocated by thread T0 here:
    #0 0x0000004a74f8 in malloc (/home/vagrant/avahi/avahi-daemon/.libs/avahi-daemon+0x4a74f8) (BuildId: 249ee71ab5864b3df21944cb6fc56865f4f2800c)
    #1 0x7f1f56e3b0ac in xmalloc /home/vagrant/avahi/avahi-common/malloc.c:68:15
    #2 0x7f1f56e3af22 in avahi_malloc /home/vagrant/avahi/avahi-common/malloc.c:107:16
    #3 0x7f1f56a8e369 in avahi_new_internal /home/vagrant/avahi/avahi-core/../avahi-common/malloc.h:50:12
    #4 0x7f1f56a8d633 in avahi_s_record_browser_prepare /home/vagrant/avahi/avahi-core/browse.c:591:15
    #5 0x7f1f56a9c83d in avahi_s_host_name_resolver_prepare /home/vagrant/avahi/avahi-core/resolve-host-name.c:251:31
    #6 0x7f1f56a9fd41 in avahi_s_host_name_resolver_new /home/vagrant/avahi/avahi-core/resolve-host-name.c:320:13
    #7 0x00000050607f in handle_line /home/vagrant/avahi/avahi-daemon/simple-protocol.c:302:39
    #8 0x0000005054b0 in handle_input /home/vagrant/avahi/avahi-daemon/simple-protocol.c:383:9
    #9 0x0000005045a7 in client_work /home/vagrant/avahi/avahi-daemon/simple-protocol.c:407:9
    #10 0x7f1f56e587d9 in avahi_simple_poll_dispatch /home/vagrant/avahi/avahi-common/simple-watch.c:585:13
    #11 0x7f1f56e58d8a in avahi_simple_poll_iterate /home/vagrant/avahi/avahi-common/simple-watch.c:605:14
    #12 0x0000004fb92c in run_server /home/vagrant/avahi/avahi-daemon/main.c:1279:18
    #13 0x0000004ecd94 in main /home/vagrant/avahi/avahi-daemon/main.c:1708:13
    #14 0x7f1f566b3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #15 0x7f1f566b3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #16 0x000000401444 in _start (/home/vagrant/avahi/avahi-daemon/.libs/avahi-daemon+0x401444) (BuildId: 249ee71ab5864b3df21944cb6fc56865f4f2800c)

SUMMARY: AddressSanitizer: heap-use-after-free /home/vagrant/avahi/avahi-core/browse.c:266:12 in lookup_multicast_callback
Shadow bytes around the buggy address:
  0x7bcf557e0500: fa fa 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x7bcf557e0580: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x7bcf557e0600: 00 00 00 00 00 fa fa fa fa fa fa fa fa fa 00 00
  0x7bcf557e0680: 00 00 00 00 00 00 00 00 00 00 00 fa fa fa fa fa
  0x7bcf557e0700: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
=>0x7bcf557e0780: fd fa fa fa fa fa fa fa fa fa fd fd[fd]fd fd fd
  0x7bcf557e0800: fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa
  0x7bcf557e0880: 00 00 00 00 00 00 00 00 00 00 00 00 00 fa fa fa
  0x7bcf557e0900: fa fa fa fa fa fa 00 00 00 00 00 00 00 00 00 00
  0x7bcf557e0980: 00 00 00 fa fa fa fa fa fa fa fa fa fd fd fd fd
  0x7bcf557e0a00: fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==196530==ABORTING
```