### PR TITLE
ci: get fuzz targets to build on FreeBSD and NetBSD

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -143,7 +143,7 @@ case "$1" in
             gobject-introspection pkgconf expat libdaemon dbus-glib dbus gdbm \
             libevent glib automake libtool libinotify qt5-core qt5-buildtools \
             gtk3 py311-pygobject py311-dbus py311-gdbm mono git socat \
-            valgrind dfuzzer check radamsa
+            valgrind dfuzzer check radamsa wget
         # some deps pull in avahi itself, remove it
         pkg remove -fy avahi-app
         ;;
@@ -161,7 +161,7 @@ case "$1" in
         PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|sed 's/_.*//')/All/" \
         PKG_RCD_SCRIPTS=yes \
             pkg_add -u autoconf automake clang compiler-rt dbus drill expat gettext git glib gmake intltool libdaemon libtool \
-            meson pkgconf socat
+            meson pkgconf socat wget
         install_dfuzzer
         install_radamsa
         ;;

--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is part of avahi.
 #
@@ -46,9 +46,11 @@ export MERGE_WITH_OSS_FUZZ_CORPORA=${MERGE_WITH_OSS_FUZZ_CORPORA:-no}
 
 export TURN_ON_NALLOCFUZZ=${TURN_ON_NALLOCFUZZ:-no}
 
+export MAKE=${MAKE:-gmake}
+
 if [[ -n "${FUZZING_ENGINE:-}" ]]; then
     apt-get update
-    apt-get install -y autoconf gettext libtool m4 automake pkg-config libexpat-dev zipmerge
+    apt-get install -y autoconf autopoint gettext libtool m4 automake pkg-config libexpat-dev zipmerge
 
     if [[ "$ARCHITECTURE" == i386 ]]; then
         apt-get install -y libexpat-dev:i386
@@ -65,16 +67,17 @@ if [[ -n "${FUZZING_ENGINE:-}" ]]; then
     # by reusing the homegrown strlcpy function even when glibc comes with strlcpy.
     # It should be removed when https://github.com/llvm/llvm-project/issues/114377 is fixed.
     if grep -qF strlcpy /usr/include/string.h && [[ "$SANITIZER" == memory ]]; then
-        sed -i '
+        sed -i.bak '
             s/#ifndef HAVE_STRLCPY/#ifdef HAVE_STRLCPY/
             s/strlcpy/msan_friendly_strlcpy/
             ' avahi-common/domain.c
     fi
 fi
 
-sed -i 's/check_inconsistencies=yes/check_inconsistencies=no/' common/acx_pthread.m4
+sed -i.bak 's/check_inconsistencies=yes/check_inconsistencies=no/' common/acx_pthread.m4
 
-if ! ./autogen.sh \
+autoreconf -ivf
+if ! ./configure \
     --disable-stack-protector --disable-qt3 --disable-qt4 --disable-qt5 --disable-gtk \
     --disable-gtk3 --disable-dbus --disable-gdbm --disable-libdaemon --disable-python \
     --disable-manpages --disable-mono --disable-monodoc --disable-glib --disable-gobject \
@@ -83,7 +86,7 @@ if ! ./autogen.sh \
     exit 1
 fi
 
-make -j"$(nproc)" V=1
+"$MAKE" -j"$(nproc)" V=1
 
 if [[ "$TURN_ON_NALLOCFUZZ" == yes ]]; then
     # It's the official nallocfuzz repository but it can diverge


### PR DESCRIPTION
to make it easier to poke various libcs to catch crashes like the one fixed in 92b659633ef0019f3202f00c9573cbfcf010630c.