### PR TITLE
ci: get fuzz targets to build on OpenBSD

### DIFF
--- a/fuzz/oss-fuzz.sh
+++ b/fuzz/oss-fuzz.sh
@@ -81,7 +81,7 @@ if ! ./configure \
     --disable-stack-protector --disable-qt3 --disable-qt4 --disable-qt5 --disable-gtk \
     --disable-gtk3 --disable-dbus --disable-gdbm --disable-libdaemon --disable-python \
     --disable-manpages --disable-mono --disable-monodoc --disable-glib --disable-gobject \
-    --disable-libevent --disable-libsystemd; then
+    --disable-libevent --disable-libsystemd --with-distro=none; then
     cat config.log
     exit 1
 fi


### PR DESCRIPTION
to make it easier to poke different libcs.

It's a follow-up to 04a9f3053f95cbfd2f9b71eadef3159d509ff2f5.