### PR TITLE
ci: no longer use the latest package set on FreeBSD

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -134,11 +134,6 @@ case "$1" in
         install_radamsa
         ;;
     install-build-deps-freebsd)
-        # Use latest package set
-        mkdir -p /usr/local/etc/pkg/repos/
-        cp /etc/pkg/FreeBSD.conf /usr/local/etc/pkg/repos/FreeBSD.conf
-        sed -i.bak -e 's|/quarterly|/latest|' /usr/local/etc/pkg/repos/FreeBSD.conf
-
         pkg install -y gettext-runtime gettext-tools gmake intltool \
             gobject-introspection pkgconf expat libdaemon dbus-glib dbus gdbm \
             libevent glib automake libtool libinotify qt5-core qt5-buildtools \


### PR DESCRIPTION
to unblock the CI on FreeBSD until the Python situation is sorted out.

See https://github.com/avahi/avahi/issues/946