### PR TITLE
fix one-byte full_name overflow in service_resolver_callback

### DIFF
--- a/avahi-compat-libdns_sd/compat.c
+++ b/avahi-compat-libdns_sd/compat.c
@@ -695,7 +695,7 @@ static void service_resolver_callback(
         case AVAHI_RESOLVER_FOUND: {
 
             char host_name_fixed[AVAHI_DOMAIN_NAME_MAX];
-            char full_name[AVAHI_DOMAIN_NAME_MAX];
+            char full_name[AVAHI_DOMAIN_NAME_MAX + 1];
             int ret;
             char *p = NULL;
             size_t l = 0;
@@ -705,7 +705,7 @@ static void service_resolver_callback(
             if ((p = avahi_new0(char, (l = avahi_string_list_serialize(txt, NULL, 0))+1)))
                 avahi_string_list_serialize(txt, p, l);
 
-            ret = avahi_service_name_join(full_name, sizeof(full_name), name, type, domain);
+            ret = avahi_service_name_join(full_name, AVAHI_DOMAIN_NAME_MAX, name, type, domain);
             assert(ret == AVAHI_OK);
 
             strcat(full_name, ".");


### PR DESCRIPTION
service_resolver_callback fills full_name[AVAHI_DOMAIN_NAME_MAX] via avahi_service_name_join and then unconditionally strcat's a trailing dot, so a resolved service whose joined name reaches sizeof-1 writes one byte past the buffer. Give full_name room for the extra dot and keep the join bounded to AVAHI_DOMAIN_NAME_MAX so the terminator stays in range.