### PR TITLE
ci: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     open-pull-requests-limit: 2
     cooldown:
       default-days: 14
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
to prevent the CI from failing on updates where several actions have to be updated at the same time among other things.