### PR TITLE
core: reject RTM_NEWADDR/RTM_DELADDR messages with no useful sockaddrs early

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -15,6 +15,7 @@ export NSS_MDNS=true
 export WITH_SYSTEMD=false
 export WITH_DBUS=false
 export OS=
+export PYTHON=python3
 
 if source /etc/os-release; then
     OS="$ID"
@@ -32,6 +33,10 @@ fi
 
 if [[ "$OS" == omnios ]]; then
     PATH="/opt/local/sbin:/opt/local/bin:$PATH"
+fi
+
+if [[ "$OS" == netbsd ]]; then
+    PYTHON=python3.14
 fi
 
 if [[ "$OS" == openbsd ]]; then
@@ -164,7 +169,7 @@ case "$1" in
         PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|sed 's/_.*//')/All/" \
         PKG_RCD_SCRIPTS=yes \
             pkg_add -u autoconf automake clang compiler-rt dbus drill expat gettext git glib gmake intltool libdaemon libtool \
-            meson pkgconf socat wget
+            meson pkgconf python314 socat wget
         install_dfuzzer
         install_radamsa
         ;;

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -41,6 +41,7 @@ valgrind_log_file="/tmp/valgrind.avahi-daemon.%p"
 
 dump_journal() {
     if [[ "$WITH_SYSTEMD" == false ]]; then
+        cat /var/adm/messages || true
         cat /var/log/messages
     else
         journalctl --sync
@@ -341,6 +342,35 @@ h="$l.local"
 run drill -p5353 @127.0.0.1 "$h" HINFO
 run drill -p5353 @127.0.0.1 _domain._udp.local ANY
 drill -Q -p5353 @127.0.0.1 "$l._ssh._tcp.local" TXT | grep org.freedesktop.Avahi.cookie
+
+
+if [[ "$OS" =~ (freebsd|netbsd|omnios|openbsd) ]]; then
+    "$PYTHON" -c '
+from socket import socket, AF_ROUTE, SOCK_RAW, AF_UNSPEC
+from sys import platform
+
+rtm_version=b"\x05"
+if "netbsd" in platform:
+    rtm_version=b"\x04"
+elif "sunos" in platform:
+    rtm_version=b"\x03"
+
+rtm_newaddr=b"\x0c"
+if "netbsd" in platform:
+    rtm_newaddr=b"\x16"
+
+s = socket(AF_ROUTE, SOCK_RAW, AF_UNSPEC)
+try:
+    s.send(b"\x00\x14" + rtm_version + rtm_newaddr + b"\x00" * 16)
+except OSError:
+    pass
+
+try:
+    s.send(b"\x00\x4c" + rtm_version + rtm_newaddr + b"\x00\xfc\x61\x69" + b"\x00" * 12 + b"\x00" * 56)
+except OSError:
+    pass
+'
+fi
 
 if [[ "$WITH_SYSTEMD" == false ]]; then
     run avahi-dnsconfd --kill

--- a/avahi-core/iface-pfroute.c
+++ b/avahi-core/iface-pfroute.c
@@ -171,6 +171,9 @@ static void rtm_addr(struct rt_msghdr *rtm, AvahiInterfaceMonitor *m)
 #endif
   }
 
+  if (!sa)
+    return;
+
   if(sa->sa_family != AF_INET && sa->sa_family != AF_INET6)
     return;
 


### PR DESCRIPTION
to prevent avahi from crashing with
```
iface-pfroute.c:179:10: runtime error: member access within null pointer of type 'struct sockaddr'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior iface-pfroute.c:179:10

Program received signal SIGSEGV, Segmentation fault.
Address not mapped to object.
0x00000008005e9056 in rtm_addr (rtm=0x7fffffffd9c0, m=0x504000000e50) at iface-pfroute.c:179
179       if(sa->sa_family != AF_INET && sa->sa_family != AF_INET6)
(gdb) bt
 #0  0x00000008005e9056 in rtm_addr (rtm=0x7fffffffd9c0, m=0x504000000e50) at iface-pfroute.c:179
 #1  0x00000008005e727e in parse_rtmsg (rtm=0x7fffffffd9c0, m=0x504000000e50) at iface-pfroute.c:284
 #2 0x00000008005e5a0e in socket_event (w=0x506000000c80, fd=14, event=AVAHI_WATCH_IN, userdata=0x504000000e50) at iface-pfroute.c:309
 #3  0x0000000800402556 in avahi_simple_poll_dispatch (s=0x50e000000040) at simple-watch.c:585
 #4  0x0000000800402b3b in avahi_simple_poll_iterate (s=0x50e000000040, timeout=-1) at simple-watch.c:605
 #5  0x000000000031c1b2 in run_server (c=0xcffd00 <config>) at main.c:1279
 #6  0x000000000030de7c in main (argc=3, argv=0x7fffffffe978) at main.c:1708
```
on FreeBSD, NetBSD and illumos.