### PR TITLE
ci: switch build workflow to Ubuntu 26.04 

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,5 @@
+# https://github.com/rhysd/actionlint/pull/683
+self-hosted-runner:
+  labels:
+    - ubuntu-26.04
+    - ubuntu-26.04-arm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+        runner: [ubuntu-26.04, ubuntu-26.04-arm]
         env:
           - { CC: "gcc", DISTCHECK: "true", VALGRIND: "true" }
           - { CC: "gcc", ASAN_UBSAN: "true" }
@@ -29,13 +29,13 @@ jobs:
           - { CC: "clang", ASAN_UBSAN: "false" }
           - { CC: "clang", ASAN_UBSAN: "true" }
         include:
-          - runner: ubuntu-24.04
+          - runner: ubuntu-26.04
             env: { CC: "clang", ASAN_UBSAN: "true", ADDITIONAL_AUTOGEN_ARGS: "--disable-dbus --disable-libsystemd --without-systemdsystemunitdir" }
-          - runner: ubuntu-24.04
+          - runner: ubuntu-26.04
             env: { CC: "gcc", VALGRIND: "true", ADDITIONAL_AUTOGEN_ARGS: "--disable-dbus --disable-libsystemd --without-systemdsystemunitdir" }
-          - runner: ubuntu-24.04
+          - runner: ubuntu-26.04
             env: { CC: "gcc", VALGRIND: "true", CFLAGS: "-g -O0 -DNDEBUG" }
-          - runner: ubuntu-24.04
+          - runner: ubuntu-26.04
             env: { CC: "clang", ASAN_UBSAN: "true", CFLAGS: "-g -O0 -DNDEBUG -ftrivial-auto-var-init=pattern" }
     env: ${{ matrix.env }}
     steps:
@@ -43,11 +43,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - run: sudo update-alternatives --set sudo /usr/bin/sudo.ws
       - run: sudo -E .github/workflows/build.sh install-build-deps
       - run: sudo -E .github/workflows/build.sh build
   coverage:
     if: github.repository == 'avahi/avahi'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -62,6 +63,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - run: sudo update-alternatives --set sudo /usr/bin/sudo.ws
       - run: sudo -E .github/workflows/build.sh install-build-deps
       - run: sudo -E .github/workflows/build.sh build
       - name: Coveralls
@@ -72,7 +74,7 @@ jobs:
           format: lcov
 
   bsd:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     defaults:
       run:
         shell: cpa.sh {0} --sync-files runner-to-vm
@@ -120,7 +122,7 @@ jobs:
           sudo -E .github/workflows/build.sh build
 
   alpine:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     container:
       image: alpine
       env: ${{ matrix.env }}

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -158,7 +158,7 @@ install_nss_mdns() {
     $MAKE check VERBOSE=1 CK_FORK=no
 
     if [[ "$DISTCHECK" == true ]]; then
-        $MAKE distcheck V=1
+        $MAKE distcheck V=1 VERBOSE=1 CK_FORK=no
     fi
 
     if [[ "$ASAN_UBSAN" == true && "$CC" == gcc ]]; then


### PR DESCRIPTION
Valgrind there is new enough to actually fail when fd leaks are
discovered.

https://github.blog/changelog/2026-06-11-new-runner-images-in-public-preview/

ci: get around libcheck fd leaks in fork mode

Now that Valgrind is new enough to fail when fd leaks are discovered
nss-mdns tests fail with:
```
==60896== FILE DESCRIPTORS: 4 open (3 inherited) at exit.
==60896== Open file descriptor 3: /tmp/check_19EdHb
==60896==    at 0x49C30D6: open (open64.c:41)
==60896==    by 0x4905B5C: try_tempname_len (tempname.c:264)
==60896==    by 0x4905B5C: gen_tempname_len (tempname.c:187)
==60896==    by 0x4905B5C: __gen_tempname (tempname.c:282)
==60896==    by 0x401119D: open_tmp_file (in /tmp/tmp.ao9fP4SrnH/nss-mdns-0.15.1/_build/sub/check_util)
==60896==    by 0x401135B: receive_test_result (in /tmp/tmp.ao9fP4SrnH/nss-mdns-0.15.1/_build/sub/check_util)
==60896==    by 0x4012D2E: srunner_run_tagged (in /tmp/tmp.ao9fP4SrnH/nss-mdns-0.15.1/_build/sub/check_util)
==60896==    by 0x400EFD5: main (check_util.c:1102)
```
The fork mode is turned off with CK_FORK=no by analogy with what was
already done in https://github.com/avahi/avahi/commit/f489eca875b913e75c1757d75c9f2bad40c0cd5e.