### PR TITLE
core: fix fd leak on wide area send error 

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -293,6 +293,11 @@ if [[ "$WITH_DBUS" == true ]]; then
     fi
 fi
 
+# https://github.com/avahi/avahi/issues/810
+if unshare -n true 2>/dev/null; then
+    export -f dump_journal run
+    unshare -n bash -exc 'run ./avahi-core/avahi-test'
+fi
 run ./avahi-core/avahi-test
 run ./avahi-core/querier-test
 

--- a/avahi-core/wide-area.c
+++ b/avahi-core/wide-area.c
@@ -184,9 +184,19 @@ static int send_to_dns_server(AvahiWideAreaLookup *l, AvahiDnsPacket *p) {
     l->watch = w;
     l->proto = a->proto;
 
-    return a->proto == AVAHI_PROTO_INET ?
+    r = a->proto == AVAHI_PROTO_INET ?
                 avahi_send_dns_packet_ipv4(l->fd, AVAHI_IF_UNSPEC, p, NULL, &a->data.ipv4, AVAHI_DNS_PORT):
                 avahi_send_dns_packet_ipv6(l->fd, AVAHI_IF_UNSPEC, p, NULL, &a->data.ipv6, AVAHI_DNS_PORT);
+
+    if (r < 0) {
+        s->poll_api->watch_free(l->watch);
+        l->watch = NULL;
+
+        close(l->fd);
+        l->fd = -EBADF;
+    }
+
+    return r;
 }
 
 static void next_dns_server(AvahiWideAreaLookupEngine *e) {


### PR DESCRIPTION
```
==26391==
==26391== FILE DESCRIPTORS: 5 open (3 inherited) at exit.
==26391== Open AF_INET socket 9: 0.0.0.0:54160 <-> <unbound>
==26391==    at 0x4A134DB: socket (syscall-template.S:120)
==26391==    by 0x48990F3: avahi_open_unicast_socket_ipv4 (socket.c:931)
==26391==    by 0x48AEABB: send_to_dns_server (wide-area.c:167)
==26391==    by 0x48AF194: avahi_wide_area_lookup_new (wide-area.c:304)
==26391==    by 0x48A0423: lookup_start (browse.c:302)
==26391==    by 0x48A0789: lookup_go (browse.c:364)
==26391==    by 0x48A0C62: defer_callback (browse.c:446)
==26391==    by 0x48860CE: expiration_event (timeeventq.c:94)
==26391==    by 0x4872E8B: timeout_callback (simple-watch.c:447)
==26391==    by 0x4873290: avahi_simple_poll_dispatch (simple-watch.c:563)
==26391==    by 0x487342B: avahi_simple_poll_iterate (simple-watch.c:605)
==26391==    by 0x48735DF: avahi_simple_poll_loop (simple-watch.c:646)
==26391==
==26391==
==26391== Exit program on first error (--exit-on-first-error=yes)
```

Fixes https://github.com/avahi/avahi/issues/810

It's a follow-up to https://github.com/avahi/avahi/commit/4e2e1ea0908d7e6ad7f38ae04fdcdf2411f8b942.