### PR TITLE
Limit user connections by checking CLIENTS_MAX

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -41,8 +41,13 @@ valgrind_log_file="/tmp/valgrind.avahi-daemon.%p"
 
 dump_journal() {
     if [[ "$WITH_SYSTEMD" == false ]]; then
-        cat /var/adm/messages || true
-        cat /var/log/messages
+        cat /var/adm/messages 2>/dev/null || true
+        cat /var/log/messages 2>/dev/null || true
+        cat /var/log/syslog 2>/dev/null || true
+        if command -v journalctl >/dev/null 2>&1; then
+            journalctl --sync 2>/dev/null || true
+            journalctl -b -t avahi-daemon --no-pager 2>/dev/null || true
+        fi
     else
         journalctl --sync
         journalctl -b -u "avahi-*" --no-pager
@@ -76,6 +81,66 @@ should_fail() {
         dump_journal
         exit 1
     fi
+}
+
+wait_for_log() {
+    local pattern="$1" i
+
+    for ((i = 0; i < 30; i++)); do
+        if [[ "$WITH_SYSTEMD" == false ]]; then
+            if grep -qF "$pattern" /var/log/messages 2>/dev/null ||
+               grep -qF "$pattern" /var/adm/messages 2>/dev/null ||
+               grep -qF "$pattern" /var/log/syslog 2>/dev/null; then
+                return 0
+            fi
+            if command -v journalctl >/dev/null 2>&1; then
+                journalctl --sync 2>/dev/null || true
+                if journalctl -b -t avahi-daemon --no-pager 2>/dev/null | grep -qF "$pattern"; then
+                    return 0
+                fi
+            fi
+        else
+            journalctl --sync 2>/dev/null || true
+            if journalctl -b -u "avahi-*" --no-pager 2>/dev/null | grep -qF "$pattern"; then
+                return 0
+            fi
+        fi
+        sleep 1
+    done
+
+    return 1
+}
+
+test_connection_limit() {
+    local pids=() i
+
+    if ! command -v socat >/dev/null 2>&1; then
+        echo "socat not available, skipping connection limit test"
+        return 0
+    fi
+
+    for ((i = 0; i < 70; i++)); do
+        sleep 30 | socat -T35 - unix-connect:"$avahi_socket" >/dev/null 2>&1 &
+        pids+=("$!")
+    done
+
+    if ! wait_for_log "refusing new client"; then
+        kill -9 "${pids[@]}" 2>/dev/null || true
+        dump_journal
+        exit 1
+    fi
+
+    kill -9 "${pids[@]}" 2>/dev/null || true
+    wait "${pids[@]}" 2>/dev/null || true
+
+    for ((i = 0; i < 30; i++)); do
+        if { printf "HELP\n"; sleep 1; } | socat -T5 - unix-connect:"$avahi_socket" | grep -qF "Available commands"; then
+            return 0
+        fi
+    done
+
+    dump_journal
+    exit 1
 }
 
 dbus_call() {
@@ -348,6 +413,7 @@ run drill -p5353 @127.0.0.1 "$h" HINFO
 run drill -p5353 @127.0.0.1 _domain._udp.local ANY
 drill -Q -p5353 @127.0.0.1 "$l._ssh._tcp.local" TXT | grep org.freedesktop.Avahi.cookie
 
+test_connection_limit
 
 if [[ "$OS" =~ (freebsd|netbsd|omnios|openbsd) ]]; then
     "$PYTHON" -c '

--- a/avahi-daemon/simple-protocol.c
+++ b/avahi-daemon/simple-protocol.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>
@@ -40,6 +41,7 @@
 #include <avahi-common/llist.h>
 #include <avahi-common/malloc.h>
 #include <avahi-common/error.h>
+#include <avahi-common/timeval.h>
 
 #include <avahi-core/log.h>
 #include <avahi-core/lookup.h>
@@ -62,6 +64,8 @@
 #define BUFFER_SIZE (20*1024)
 
 #define CLIENTS_MAX 50
+
+#define LOG_RATELIMIT_USEC (5 * 1000000LL)
 
 typedef struct Client Client;
 typedef struct Server Server;
@@ -102,6 +106,9 @@ struct Server {
 
     unsigned n_clients;
     int remove_socket;
+
+    struct timeval last_accept_error;
+    struct timeval last_refuse_log;
 };
 
 static Server *server = NULL;
@@ -438,17 +445,45 @@ static void client_work(AvahiWatch *watch, AVAHI_GCC_UNUSED int fd, AvahiWatchEv
         (c->inbuf_length < sizeof(c->inbuf) ? AVAHI_WATCH_IN : 0));
 }
 
+static int log_ratelimit(struct timeval *last) {
+    int ret;
+
+    assert(last);
+
+    if ((last->tv_sec != 0 || last->tv_usec != 0) &&
+        avahi_age(last) < LOG_RATELIMIT_USEC)
+        return 0;
+
+    ret = gettimeofday(last, NULL);
+    if (ret < 0) {
+        avahi_log_warn("gettimeofday(): %s", strerror(errno));
+        return 0;
+    }
+
+    return 1;
+}
+
 static void server_work(AVAHI_GCC_UNUSED AvahiWatch *watch, int fd, AvahiWatchEvent events, void *userdata) {
     Server *s = userdata;
+    int ret;
 
     assert(s);
 
     if (events & AVAHI_WATCH_IN) {
         int cfd;
 
-        if ((cfd = accept(fd, NULL, NULL)) < 0)
-            avahi_log_error("accept(): %s", strerror(errno));
-        else
+        if ((cfd = accept(fd, NULL, NULL)) < 0) {
+            if (log_ratelimit(&s->last_accept_error))
+                avahi_log_error("accept(): %s", strerror(errno));
+        } else if (s->n_clients >= CLIENTS_MAX) {
+            ret = close(cfd);
+            if (ret < 0) {
+                avahi_log_warn("close(): %s", strerror(errno));
+            }
+
+            if (log_ratelimit(&s->last_refuse_log))
+                avahi_log_warn("Maximum number of connections (%u) reached, refusing new client.", (unsigned) CLIENTS_MAX);
+        } else
             client_new(s, cfd);
     }
 }
@@ -469,6 +504,8 @@ int simple_protocol_setup(const AvahiPoll *poll_api) {
     server->n_clients = 0;
     AVAHI_LLIST_HEAD_INIT(Client, server->clients);
     server->watch = NULL;
+    server->last_accept_error = (struct timeval){.tv_sec = 0, .tv_usec = 0};
+    server->last_refuse_log = (struct timeval){.tv_sec = 0, .tv_usec = 0};
 
     u = umask(0000);
 


### PR DESCRIPTION
User connection are tested against CLIENTS_MAX. When limit exceeded connection is accepted and dropped immediately.
Also add LOG_RATELIMIT_USEC variable so logging dropped connection will not exceed this limit.
Tested with smoke test that is also added in this pull request

Trying to create such a small changes so it will be worth more to the project than the time it takes to review it.
Smaller version than #808 and #895