### PR TITLE
ci: preserve project on Packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -33,6 +33,7 @@ jobs:
   - fedora-all-x86_64
 - job: copr_build
   trigger: commit
+  preserve_project: true
   targets:
   - fedora-all-aarch64
   - fedora-all-i386


### PR DESCRIPTION
to prevent OpenScanHub from failing with
```
It was not possible to download the SRPMs needed for the differential scan
```

https://packit.dev/posts/openscanhub-prototype#setup