### PR TITLE
Continue work on CVE-2025-59529

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -234,6 +234,196 @@ check_rlimit_nofile() {
     [[ "$_rlimit_nofile" == "$_rlimit_nofile_conf" ]]
 }
 
+# CVE-2025-59529: Test simple protocol client connection limits.
+# Restarts the daemon with rlimit-nofile=100 so the limits are
+# reachable with a small number of connections:
+#   max_clients = min(4096, 100 * 3/4) = 75
+#   max_uid_clients = 75 / 2 = 37
+test_simple_protocol_limits() {
+    local _i _refused _pid
+    # _saved_rlimit and _pids are intentionally NOT local so that
+    # _simple_protocol_limits_cleanup can access them from the EXIT
+    # trap even if set -e kills the script outside this function.
+    _saved_rlimit=""
+    _pids=()
+
+    _saved_rlimit=$(perl -lne 'print $1 if /^(#?rlimit-nofile=.*)/' "$avahi_daemon_conf")
+    sed -i.bak 's|^#*rlimit-nofile=.*|rlimit-nofile=100|' "$avahi_daemon_conf"
+
+    # Ensure config is restored and flood connections are cleaned up
+    # on any exit, including set -e failures.
+    trap '_simple_protocol_limits_cleanup' EXIT
+
+    if [[ "$WITH_SYSTEMD" == true ]]; then
+        run systemctl restart avahi-daemon
+    elif [[ "$VALGRIND" == true ]]; then
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        valgrind --log-file="$valgrind_log_file" --leak-check=full \
+            --track-origins=yes --track-fds=yes --error-exitcode=1 \
+            --trace-children=yes \
+            -s --suppressions=.github/workflows/avahi-daemon.supp \
+            avahi-daemon -D --debug --no-drop-root --no-proc-title
+    elif [[ "$ASAN_UBSAN" == true ]]; then
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        ASAN_OPTIONS="$ASAN_OPTIONS:log_path=/tmp/asan.avahi-daemon" \
+        UBSAN_OPTIONS="$UBSAN_OPTIONS:log_path=/tmp/ubsan.avahi-daemon" \
+            avahi-daemon -D --debug --no-drop-root
+    else
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        avahi-daemon -D --debug
+    fi
+    # Allow daemon to finish startup and bind the socket
+    sleep 2
+
+    _pid=$(cat "$avahi_daemon_pid_file")
+    kill -0 "$_pid"
+
+    printf "%s\n" "HELP" | socat -t3 - "unix-connect:$avahi_socket,shut-none" \
+        | grep -q "Available commands"
+
+    # --- Per-UID limit ---
+    # Open 40 connections as a non-root user. With max_uid_clients=37,
+    # connections 38+ are refused for that UID.
+    # Root (uid=0) is exempt from per-UID limits, so a privilege drop
+    # is required. runuser is Linux-specific; skip on other platforms.
+    if command -v runuser >/dev/null 2>&1; then
+        # Take a baseline count so we only assert on new refusals
+        # from this flood, not stale entries from prior test runs.
+        local _baseline_uid
+        _baseline_uid=$(_simple_protocol_limits_count "too many uid clients")
+
+        _pids=()
+        for _i in $(seq 1 40); do
+            runuser -u avahi -- \
+                socat -T30 PIPE "unix-connect:$avahi_socket,shut-none" &
+            _pids+=("$!")
+        done
+        # socat connect() is synchronous and the daemon processes
+        # accept() in its event loop immediately; 3s is sufficient.
+        sleep 3
+
+        kill -0 "$_pid"
+
+        _refused=$(( $(_simple_protocol_limits_count "too many uid clients") - _baseline_uid ))
+        if [[ "$_refused" -le 0 ]]; then
+            dump_journal || true
+            exit 1
+        fi
+
+        for _i in "${_pids[@]}"; do
+            kill "$_i" 2>/dev/null || true
+        done
+        _pids=()
+        # Allow the daemon to process disconnections and free slots
+        sleep 2
+
+        printf "%s\n" "HELP" \
+            | socat -t3 - "unix-connect:$avahi_socket,shut-none" \
+            | grep -q "Available commands"
+    fi
+
+    # --- Total client limit ---
+    # Open 80 connections as root. Root bypasses per-UID limits but
+    # the global max_clients=75 still applies.
+    local _baseline_total
+    _baseline_total=$(_simple_protocol_limits_count "too many clients$")
+
+    _pids=()
+    for _i in $(seq 1 80); do
+        socat -T30 PIPE "unix-connect:$avahi_socket,shut-none" &
+        _pids+=("$!")
+    done
+    sleep 3
+
+    kill -0 "$_pid"
+
+    # Verify refusal was logged. The trailing $ anchor distinguishes
+    # "too many clients" (global) from "too many uid clients: N" (per-UID).
+    # On non-systemd BSD, debug messages may not reach syslog depending
+    # on the syslog.conf, so only assert the count on systemd or Linux.
+    _refused=$(( $(_simple_protocol_limits_count "too many clients$") - _baseline_total ))
+    if [[ "$WITH_SYSTEMD" == true || "$OS" == ubuntu ]] && [[ "$_refused" -le 0 ]]; then
+        dump_journal || true
+        exit 1
+    fi
+
+    for _i in "${_pids[@]}"; do
+        kill "$_i" 2>/dev/null || true
+    done
+    _pids=()
+    sleep 2
+
+    # Daemon accepts connections after both floods
+    printf "%s\n" "HELP" | socat -t3 - "unix-connect:$avahi_socket,shut-none" \
+        | grep -q "Available commands"
+
+    # Cleanup runs via the EXIT trap; clear it on success so it
+    # does not interfere with the rest of the script.
+    _simple_protocol_limits_cleanup
+    trap - EXIT
+
+    # Restart daemon with original config for remaining tests
+    if [[ "$WITH_SYSTEMD" == true ]]; then
+        run systemctl restart avahi-daemon
+    elif [[ "$VALGRIND" == true ]]; then
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        valgrind --log-file="$valgrind_log_file" --leak-check=full \
+            --track-origins=yes --track-fds=yes --error-exitcode=1 \
+            --trace-children=yes \
+            -s --suppressions=.github/workflows/avahi-daemon.supp \
+            avahi-daemon -D --debug --no-drop-root --no-proc-title
+    elif [[ "$ASAN_UBSAN" == true ]]; then
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        ASAN_OPTIONS="$ASAN_OPTIONS:log_path=/tmp/asan.avahi-daemon" \
+        UBSAN_OPTIONS="$UBSAN_OPTIONS:log_path=/tmp/ubsan.avahi-daemon" \
+            avahi-daemon -D --debug --no-drop-root
+    else
+        avahi-daemon --kill 2>/dev/null || true
+        sleep 1
+        avahi-daemon -D --debug
+    fi
+    sleep 2
+}
+
+# Helpers for test_simple_protocol_limits. Defined at top level
+# because nested functions have no precedent in this file.
+
+_simple_protocol_limits_cleanup() {
+    for _i in "${_pids[@]}"; do
+        kill "$_i" 2>/dev/null || true
+    done
+    _pids=()
+
+    if [[ -n "${_saved_rlimit:-}" ]]; then
+        sed -i.bak "s|^rlimit-nofile=100|$_saved_rlimit|" "$avahi_daemon_conf"
+    else
+        sed -i.bak '/^rlimit-nofile=100/d' "$avahi_daemon_conf"
+    fi
+    rm -f "${avahi_daemon_conf}.bak"
+}
+
+_simple_protocol_limits_count() {
+    local _pattern="$1" _count=0
+
+    if [[ "$WITH_SYSTEMD" == true ]]; then
+        journalctl --sync
+        _count=$(journalctl -b -u avahi-daemon --no-pager \
+            | grep -c "$_pattern") || _count=0
+    elif [[ -f /var/log/syslog ]]; then
+        _count=$(grep -c "$_pattern" /var/log/syslog) || _count=0
+    elif [[ -f /var/log/messages ]]; then
+        _count=$(grep -c "$_pattern" /var/log/messages) || _count=0
+    elif [[ -f /var/adm/messages ]]; then
+        _count=$(grep -c "$_pattern" /var/adm/messages) || _count=0
+    fi
+
+    printf "%d" "$_count"
+}
 if [[ "$OS" != openbsd ]]; then
     install_nss_mdns
 fi
@@ -341,6 +531,8 @@ if [[ "$WITH_DBUS" == true ]]; then
 fi
 
 check_rlimit_nofile
+
+test_simple_protocol_limits
 
 l=$(hostname | sed 's/\.local$//')
 h="$l.local"

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -240,7 +240,7 @@ check_rlimit_nofile() {
 #   max_clients = min(4096, 100 * 3/4) = 75
 #   max_uid_clients = 75 / 2 = 37
 test_simple_protocol_limits() {
-    local _i _refused _pid
+    local _i _pid _dnsconfd_was_active _limits
     # _saved_rlimit and _pids are intentionally NOT local so that
     # _simple_protocol_limits_cleanup can access them from the EXIT
     # trap even if set -e kills the script outside this function.
@@ -252,6 +252,18 @@ test_simple_protocol_limits() {
 
     trap '_simple_protocol_limits_cleanup' EXIT
 
+    # avahi-dnsconfd is itself a simple protocol client so stop it first
+    _dnsconfd_was_active=false
+    if [[ "$WITH_SYSTEMD" == true ]]; then
+        if systemctl is-active --quiet avahi-dnsconfd 2>/dev/null; then
+            _dnsconfd_was_active=true
+        fi
+        systemctl stop avahi-dnsconfd 2>/dev/null || true
+    else
+        avahi-dnsconfd --kill 2>/dev/null || true
+    fi
+    sleep 2
+
     if [[ "$WITH_SYSTEMD" == true ]]; then
         # systemd's LimitNOFILE overrides the daemon config
         mkdir -p /run/systemd/system/avahi-daemon.service.d
@@ -260,11 +272,11 @@ test_simple_protocol_limits() {
         systemctl daemon-reload
         run systemctl restart avahi-daemon
     elif [[ "$VALGRIND" == true ]]; then
+        _pid=$(cat "$avahi_daemon_pid_file")
         avahi-daemon --kill 2>/dev/null || true
         sleep 1
-        # Set RLIMIT_NOFILE before Valgrind starts; Valgrind
-        # intercepts setrlimit() so the daemon config alone
-        # is not enough.
+        _simple_protocol_limits_check_valgrind_log "$_pid"
+        # set ulimit for valgrind to 100
         (ulimit -n 100 && \
         valgrind --log-file="$valgrind_log_file" --leak-check=full \
             --track-origins=yes --track-fds=yes --error-exitcode=1 \
@@ -282,85 +294,25 @@ test_simple_protocol_limits() {
         sleep 1
         avahi-daemon -D --debug
     fi
-    if [[ "$WITH_SYSTEMD" == false ]]; then
-        avahi-dnsconfd -D 2>/dev/null || true
-    fi
     sleep 2
 
     _pid=$(cat "$avahi_daemon_pid_file")
     kill -0 "$_pid"
 
-    printf "%s\n" "HELP" | socat -t3 - "unix-connect:$avahi_socket,shut-none" \
-        | grep -q "Available commands"
+    _simple_protocol_limits_assert_empty
 
-    # --- Per-UID limit ---
-    # Open 40 connections as a non-root user. With max_uid_clients=37,
-    # connections 38+ are refused for that UID.
-    # Root (uid=0) is exempt from per-UID limits, so a privilege drop
-    # is required. runuser is Linux-specific; skip on other platforms.
-    if command -v runuser >/dev/null 2>&1; then
-        # Take a baseline count so we only assert on new refusals
-        # from this flood, not stale entries from prior test runs.
-        local _baseline_uid
-        _baseline_uid=$(_simple_protocol_limits_count "too many uid clients")
-
-        _pids=()
-        for _i in $(seq 1 40); do
-            runuser -u avahi -- \
-                socat -T30 PIPE "unix-connect:$avahi_socket,shut-none" &
-            _pids+=("$!")
-        done
-        # socat connect() is synchronous and the daemon processes
-        # accept() in its event loop immediately; 3s is sufficient.
-        sleep 3
-
-        kill -0 "$_pid"
-
-        _refused=$(( $(_simple_protocol_limits_count "too many uid clients") - _baseline_uid ))
-        if [[ "$_refused" -le 0 ]]; then
-            dump_journal || true
-            exit 1
-        fi
-
-        for _i in "${_pids[@]}"; do
-            kill "$_i" 2>/dev/null || true
-        done
-        _pids=()
-        # Allow the daemon to process disconnections and free slots
-        sleep 2
-
-        printf "%s\n" "HELP" \
-            | socat -t3 - "unix-connect:$avahi_socket,shut-none" \
-            | grep -q "Available commands"
-    fi
-
-    # --- Total client limit ---
-    # Open 80 connections as root. Root bypasses per-UID limits but
-    # the global max_clients=75 still applies.
-    local _baseline_total
-    _baseline_total=$(_simple_protocol_limits_count "too many clients$")
-
-    _pids=()
-    for _i in $(seq 1 80); do
-        socat -T30 PIPE "unix-connect:$avahi_socket,shut-none" &
-        _pids+=("$!")
-    done
-    sleep 3
-
-    kill -0 "$_pid"
-
-    # Verify refusal was logged. The trailing $ anchor distinguishes
-    # "too many clients" (global) from "too many uid clients: N" (per-UID).
-    # On non-systemd BSD, debug messages may not reach syslog depending
-    # on the syslog.conf, so only assert the count on systemd or Linux.
-    _refused=$(( $(_simple_protocol_limits_count "too many clients$") - _baseline_total ))
-    if [[ "$WITH_SYSTEMD" == true || "$OS" == ubuntu ]] && [[ "$_refused" -le 0 ]]; then
-        dump_journal || true
-        exit 1
+    if _limits=$(_simple_protocol_limits_read_limits); then
+        _simple_protocol_limits_assert_boundaries \
+            "$_pid" "${_limits%% *}" "${_limits#* }"
+    else
+        printf "Could not read the client limits from the log, skipping the boundary assertions\n" >&2
     fi
 
     for _i in "${_pids[@]}"; do
         kill "$_i" 2>/dev/null || true
+    done
+    for _i in "${_pids[@]}"; do
+        wait "$_i" 2>/dev/null || true
     done
     _pids=()
     sleep 2
@@ -374,12 +326,123 @@ test_simple_protocol_limits() {
     _simple_protocol_limits_cleanup
     trap - EXIT
 
-    # Restart daemon with original config for remaining tests
+    _simple_protocol_limits_restore_daemon "$_pid" "$_dnsconfd_was_active"
+}
+
+_simple_protocol_limits_assert_boundaries() {
+    local _pid="$1" _max_clients="$2" _max_uid_clients="$3"
+    local _baseline_total _baseline_uid _i _refused
+
+    # --- Per-UID limit ---
+    # Root (uid=0) is exempt from per-UID limits, so a privilege drop
+    # is required. runuser is Linux-specific; skip on other platforms.
+    if command -v runuser >/dev/null 2>&1; then
+        # Take a baseline count so we only assert on new refusals
+        # from this flood, not stale entries from prior test runs.
+        _baseline_uid=$(_simple_protocol_limits_count "too many uid clients")
+
+        _pids=()
+        for _i in $(seq 1 "$_max_uid_clients"); do
+            runuser -u avahi -- \
+                socat -T30 PIPE "unix-connect:$avahi_socket,shut-none" &
+            _pids+=("$!")
+        done
+        # socat connect() is synchronous and the daemon processes
+        # accept() in its event loop immediately; 3s is sufficient.
+        sleep 3
+
+        kill -0 "$_pid"
+
+        # The exact boundary must be accepted without a refusal.
+        _simple_protocol_limits_assert_alive "$_max_uid_clients" "${_pids[@]}"
+        _refused=$(( $(_simple_protocol_limits_count "too many uid clients") - _baseline_uid ))
+        if [[ "$_refused" -ne 0 ]]; then
+            dump_journal || true
+            exit 1
+        fi
+
+        if getent passwd nobody >/dev/null 2>&1; then
+            printf "%s\n" "HELP" \
+                | runuser -u nobody -- \
+                    socat -t3 - "unix-connect:$avahi_socket,shut-none" \
+                | grep -q "Available commands"
+        fi
+
+        # Cross the per-UID boundary by three
+        for _i in $(seq 1 3); do
+            runuser -u avahi -- \
+                socat -T30 PIPE "unix-connect:$avahi_socket,shut-none" &
+            _pids+=("$!")
+        done
+        sleep 3
+
+        _simple_protocol_limits_assert_alive "$_max_uid_clients" "${_pids[@]}"
+        _refused=$(( $(_simple_protocol_limits_count "too many uid clients") - _baseline_uid ))
+        if [[ "$_refused" -ne 3 ]]; then
+            dump_journal || true
+            exit 1
+        fi
+
+        for _i in "${_pids[@]}"; do
+            kill "$_i" 2>/dev/null || true
+        done
+        for _i in "${_pids[@]}"; do
+            wait "$_i" 2>/dev/null || true
+        done
+        _pids=()
+        # Allow the daemon to process disconnections and free slots
+        sleep 2
+
+        _simple_protocol_limits_assert_empty
+    fi
+
+    # --- Total client limit ---
+    _baseline_total=$(_simple_protocol_limits_count "too many clients$")
+
+    _pids=()
+    for _i in $(seq 1 "$_max_clients"); do
+        socat -T30 PIPE "unix-connect:$avahi_socket,shut-none" &
+        _pids+=("$!")
+    done
+    sleep 3
+
+    kill -0 "$_pid"
+
+    # The exact global boundary must be accepted without a refusal.
+    _simple_protocol_limits_assert_alive "$_max_clients" "${_pids[@]}"
+    _refused=$(( $(_simple_protocol_limits_count "too many clients$") - _baseline_total ))
+    if [[ "$WITH_SYSTEMD" == true || "$OS" == ubuntu ]] && [[ "$_refused" -ne 0 ]]; then
+        dump_journal || true
+        exit 1
+    fi
+
+    # Cross the global boundary by five.
+    for _i in $(seq 1 5); do
+        socat -T30 PIPE "unix-connect:$avahi_socket,shut-none" &
+        _pids+=("$!")
+    done
+    sleep 3
+
+    _simple_protocol_limits_assert_alive "$_max_clients" "${_pids[@]}"
+
+    # Verify refusal was logged.
+    _refused=$(( $(_simple_protocol_limits_count "too many clients$") - _baseline_total ))
+    if [[ "$WITH_SYSTEMD" == true || "$OS" == ubuntu ]] && [[ "$_refused" -ne 5 ]]; then
+        dump_journal || true
+        exit 1
+    fi
+}
+
+# Restart the daemon with the original config for the remaining tests.
+_simple_protocol_limits_restore_daemon() {
+    local _pid="$1" _dnsconfd_was_active="$2"
+
     if [[ "$WITH_SYSTEMD" == true ]]; then
         run systemctl restart avahi-daemon
     elif [[ "$VALGRIND" == true ]]; then
         avahi-daemon --kill 2>/dev/null || true
         sleep 1
+        _simple_protocol_limits_check_valgrind_log "$_pid"
         valgrind --log-file="$valgrind_log_file" --leak-check=full \
             --track-origins=yes --track-fds=yes --error-exitcode=1 \
             --trace-children=yes \
@@ -396,18 +459,32 @@ test_simple_protocol_limits() {
         sleep 1
         avahi-daemon -D --debug
     fi
-    if [[ "$WITH_SYSTEMD" == false ]]; then
+    if [[ "$WITH_SYSTEMD" == true ]]; then
+        if [[ "$_dnsconfd_was_active" == true ]]; then
+            systemctl start avahi-dnsconfd 2>/dev/null || true
+        fi
+    else
         avahi-dnsconfd -D 2>/dev/null || true
     fi
     sleep 2
 }
 
-# Helpers for test_simple_protocol_limits. Defined at top level
-# because nested functions have no precedent in this file.
+_simple_protocol_limits_check_valgrind_log() {
+    local _pid="$1"
+    local _log_file="${valgrind_log_file//%p/$_pid}"
+
+    cat "$_log_file"
+    if grep -qE 'ERROR SUMMARY:\s+[^0]' "$_log_file"; then
+        return 1
+    fi
+}
 
 _simple_protocol_limits_cleanup() {
     for _i in "${_pids[@]}"; do
         kill "$_i" 2>/dev/null || true
+    done
+    for _i in "${_pids[@]}"; do
+        wait "$_i" 2>/dev/null || true
     done
     _pids=()
 
@@ -422,23 +499,82 @@ _simple_protocol_limits_cleanup() {
     systemctl daemon-reload 2>/dev/null || true
 }
 
+_simple_protocol_limits_log() {
+    if command -v journalctl >/dev/null 2>&1 && journalctl --sync 2>/dev/null; then
+        journalctl -b -t avahi-daemon --no-pager
+    elif [[ -f /var/log/syslog ]]; then
+        cat /var/log/syslog
+    elif [[ -f /var/log/messages ]]; then
+        cat /var/log/messages
+    elif [[ -f /var/adm/messages ]]; then
+        cat /var/adm/messages
+    fi
+}
+
 _simple_protocol_limits_count() {
     local _pattern="$1" _count=0
 
-    if [[ "$WITH_SYSTEMD" == true ]]; then
-        journalctl --sync
-        _count=$(journalctl -b -u avahi-daemon --no-pager \
-            | grep -c "$_pattern") || _count=0
-    elif [[ -f /var/log/syslog ]]; then
-        _count=$(grep -c "$_pattern" /var/log/syslog) || _count=0
-    elif [[ -f /var/log/messages ]]; then
-        _count=$(grep -c "$_pattern" /var/log/messages) || _count=0
-    elif [[ -f /var/adm/messages ]]; then
-        _count=$(grep -c "$_pattern" /var/adm/messages) || _count=0
-    fi
+    _count=$(_simple_protocol_limits_log | grep -c "$_pattern") || _count=0
 
     printf "%d" "$_count"
 }
+
+# Open one connection and confirm the daemon logs it as client 1 of 1.
+_simple_protocol_limits_assert_empty() {
+    local _line="" _n=""
+
+    printf "%s\n" "HELP" | socat -t3 - "unix-connect:$avahi_socket,shut-none" \
+        | grep -q "Available commands"
+
+    if [[ "$WITH_SYSTEMD" != true && "$OS" != ubuntu ]]; then
+        return 0
+    fi
+
+    _line=$(_simple_protocol_limits_log | grep " accepted: " | tail -n1) || _line=""
+    if [[ "$_line" =~ simple\ client\ [0-9]+/([0-9]+)\ accepted ]]; then
+        _n="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ "$_n" != 1 ]]; then
+        printf "Expected an empty daemon, probe was accepted as client %s\n" \
+            "${_n:-<none logged>}" >&2
+        dump_journal || true
+        exit 1
+    fi
+}
+
+_simple_protocol_limits_read_limits() {
+    local _line=""
+
+    _line=$(_simple_protocol_limits_log \
+        | grep "Maximal simple clients:" | tail -n1) || _line=""
+
+    if [[ "$_line" =~ Maximal\ simple\ clients:\ ([0-9]+),\ per_uid:\ ([0-9]+) ]]; then
+        printf "%s %s\n" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+        return 0
+    fi
+
+    return 1
+}
+
+_simple_protocol_limits_assert_alive() {
+    local _expected="$1" _pid _actual=0
+
+    shift
+    for _pid in "$@"; do
+        if kill -0 "$_pid" 2>/dev/null; then
+            ((_actual+=1))
+        fi
+    done
+
+    if [[ "$_actual" -ne "$_expected" ]]; then
+        printf "Expected %d live simple clients, found %d\n" \
+            "$_expected" "$_actual" >&2
+        dump_journal || true
+        exit 1
+    fi
+}
+
 if [[ "$OS" != openbsd ]]; then
     install_nss_mdns
 fi

--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -250,20 +250,27 @@ test_simple_protocol_limits() {
     _saved_rlimit=$(perl -lne 'print $1 if /^(#?rlimit-nofile=.*)/' "$avahi_daemon_conf")
     sed -i.bak 's|^#*rlimit-nofile=.*|rlimit-nofile=100|' "$avahi_daemon_conf"
 
-    # Ensure config is restored and flood connections are cleaned up
-    # on any exit, including set -e failures.
     trap '_simple_protocol_limits_cleanup' EXIT
 
     if [[ "$WITH_SYSTEMD" == true ]]; then
+        # systemd's LimitNOFILE overrides the daemon config
+        mkdir -p /run/systemd/system/avahi-daemon.service.d
+        printf '[Service]\nLimitNOFILE=100\n' \
+            > /run/systemd/system/avahi-daemon.service.d/test-rlimit.conf
+        systemctl daemon-reload
         run systemctl restart avahi-daemon
     elif [[ "$VALGRIND" == true ]]; then
         avahi-daemon --kill 2>/dev/null || true
         sleep 1
+        # Set RLIMIT_NOFILE before Valgrind starts; Valgrind
+        # intercepts setrlimit() so the daemon config alone
+        # is not enough.
+        (ulimit -n 100 && \
         valgrind --log-file="$valgrind_log_file" --leak-check=full \
             --track-origins=yes --track-fds=yes --error-exitcode=1 \
             --trace-children=yes \
             -s --suppressions=.github/workflows/avahi-daemon.supp \
-            avahi-daemon -D --debug --no-drop-root --no-proc-title
+            avahi-daemon -D --debug --no-drop-root --no-proc-title)
     elif [[ "$ASAN_UBSAN" == true ]]; then
         avahi-daemon --kill 2>/dev/null || true
         sleep 1
@@ -275,7 +282,9 @@ test_simple_protocol_limits() {
         sleep 1
         avahi-daemon -D --debug
     fi
-    # Allow daemon to finish startup and bind the socket
+    if [[ "$WITH_SYSTEMD" == false ]]; then
+        avahi-dnsconfd -D 2>/dev/null || true
+    fi
     sleep 2
 
     _pid=$(cat "$avahi_daemon_pid_file")
@@ -387,6 +396,9 @@ test_simple_protocol_limits() {
         sleep 1
         avahi-daemon -D --debug
     fi
+    if [[ "$WITH_SYSTEMD" == false ]]; then
+        avahi-dnsconfd -D 2>/dev/null || true
+    fi
     sleep 2
 }
 
@@ -405,6 +417,9 @@ _simple_protocol_limits_cleanup() {
         sed -i.bak '/^rlimit-nofile=100/d' "$avahi_daemon_conf"
     fi
     rm -f "${avahi_daemon_conf}.bak"
+
+    rm -f /run/systemd/system/avahi-daemon.service.d/test-rlimit.conf 2>/dev/null
+    systemctl daemon-reload 2>/dev/null || true
 }
 
 _simple_protocol_limits_count() {
@@ -570,7 +585,7 @@ except OSError:
 fi
 
 if [[ "$WITH_SYSTEMD" == false ]]; then
-    run avahi-dnsconfd --kill
+    avahi-dnsconfd --kill 2>/dev/null || true
 
     if [[ "$WITH_DBUS" == true ]]; then
         run dfuzzer -v -n org.freedesktop.Avahi

--- a/avahi-daemon/main.c
+++ b/avahi-daemon/main.c
@@ -1187,11 +1187,23 @@ static int run_server(DaemonConfig *c) {
         goto finish;
     }
 
-    /* We accept clients only of 3/4 file descriptors allowed
-     * in this process. Keep extra for UDP sockets. */
-    nofiles = config.rlimit_nofile * 3/4;
-    if (nofiles > MAX_NOFILE_LIMIT)
-        nofiles = MAX_NOFILE_LIMIT;
+    /* Derive the simple protocol client limit from the actual effective
+     * RLIMIT_NOFILE, not the configured value, because setrlimit() may
+     * have failed (hard limit too low) or --no-rlimits may be in use.
+     * Reading the live limit ensures we never try to hold more fds than
+     * the process is actually allowed. */
+    {
+        struct rlimit rl;
+        rlim_t effective_nofile = config.rlimit_nofile;
+
+        if (getrlimit(RLIMIT_NOFILE, &rl) == 0)
+            effective_nofile = rl.rlim_cur;
+
+        if (effective_nofile > MAX_NOFILE_LIMIT)
+            nofiles = MAX_NOFILE_LIMIT;
+        else
+            nofiles = (unsigned)(effective_nofile * 3 / 4);
+    }
     if (simple_protocol_setup(poll_api, nofiles) < 0)
         goto finish;
 

--- a/avahi-daemon/main.c
+++ b/avahi-daemon/main.c
@@ -1201,8 +1201,10 @@ static int run_server(DaemonConfig *c) {
 
         if (effective_nofile > MAX_NOFILE_LIMIT)
             nofiles = MAX_NOFILE_LIMIT;
-        else
+        else if (effective_nofile > 0)
             nofiles = (unsigned)(effective_nofile * 3 / 4);
+        else
+            nofiles = 1;
     }
     if (simple_protocol_setup(poll_api, nofiles) < 0)
         goto finish;

--- a/avahi-daemon/main.c
+++ b/avahi-daemon/main.c
@@ -90,8 +90,8 @@
 #include "dbus-protocol.h"
 #endif
 
-/* Maximal number of concurrent simple protocol clients. */
-#define MAX_NOFILE_LIMIT 4096
+/* Maximal number of concurrent simple protocol clients */
+#define MAX_SIMPLE_CLIENTS 4096
 
 AvahiServer *avahi_server = NULL;
 AvahiSimplePoll *simple_poll_api = NULL;
@@ -1195,14 +1195,17 @@ static int run_server(DaemonConfig *c) {
     {
         struct rlimit rl;
         rlim_t effective_nofile = config.rlimit_nofile;
+        rlim_t share;
 
         if (getrlimit(RLIMIT_NOFILE, &rl) == 0)
             effective_nofile = rl.rlim_cur;
 
-        if (effective_nofile > MAX_NOFILE_LIMIT)
-            nofiles = MAX_NOFILE_LIMIT;
-        else if (effective_nofile > 0)
-            nofiles = (unsigned)(effective_nofile * 3 / 4);
+        share = effective_nofile / 2;
+
+        if (share > MAX_SIMPLE_CLIENTS)
+            nofiles = MAX_SIMPLE_CLIENTS;
+        else if (share > 0)
+            nofiles = (unsigned) share;
         else
             nofiles = 1;
     }

--- a/avahi-daemon/simple-protocol.c
+++ b/avahi-daemon/simple-protocol.c
@@ -574,7 +574,7 @@ static int is_client_allowed(Server *s, int cfd, AvahiCred *cred) {
      * "unknown UID" bucket, which effectively limits them to max_uid_clients
      * instead of max_clients. This is an acceptable tradeoff: returning 0
      * (root) would silently skip per-UID enforcement entirely. */
-    if (uid != 0 && n_clients > s->max_uid_clients) {
+    if (uid != 0 && n_clients >= s->max_uid_clients) {
         /* There are enough clients to reach the limit for one UID.
          * Check this UID does not have too many connections already. */
         Client *c;

--- a/avahi-daemon/simple-protocol.c
+++ b/avahi-daemon/simple-protocol.c
@@ -64,85 +64,99 @@
 
 #define BUFFER_SIZE (20*1024)
 
-#if __linux__
+#ifdef __linux__
 /* Linux specific support, man 7 unix */
 typedef struct ucred AvahiCred;
 
-
 static uid_t credentials_getuid(const AvahiCred *cred) {
-	return cred->uid;
+    return cred->uid;
 }
 
 static gid_t credentials_getgid(const AvahiCred *cred) {
-	return cred->gid;
+    return cred->gid;
 }
 
 static pid_t credentials_getpid(const AvahiCred *cred) {
-	return cred->pid;
+    return cred->pid;
 }
 
 static int credentials_getsockopt(int fd, AvahiCred *cred, socklen_t *len) {
     *len = sizeof(*cred);
-    memset(cred, 0, sizeof(*cred));
-    return getsockopt(fd, SOL_SOCKET, SO_PEERCRED, cred, len);
+    if (getsockopt(fd, SOL_SOCKET, SO_PEERCRED, cred, len) != 0)
+        return -1;
+    if (*len != sizeof(*cred)) {
+        avahi_log_error("credentials_getsockopt: unexpected credential size %u (expected %zu)",
+                        (unsigned)*len, sizeof(*cred));
+        return -1;
+    }
+    return 0;
 }
 
-#  define CRED_FMT     "uid=%lu gid=%lu pid=%lu"
-#  define CRED_VALS(ucred) (long)credentials_getuid(ucred), (long)credentials_getgid(ucred), (long)credentials_getpid(ucred)
+#  define CRED_FMT     "uid=%lu gid=%lu pid=%ld"
+#  define CRED_ARGS(ucred) , (unsigned long)credentials_getuid(ucred), (unsigned long)credentials_getgid(ucred), (long)credentials_getpid(ucred)
 
 #elif defined(HAVE_STRUCT_XUCRED) && defined(XUCRED_VERSION)
 /* FreeBSD support, man 4 unix */
 typedef struct xucred AvahiCred;
 
 static int credentials_version_check(const AvahiCred *cred) {
-	if (cred->cr_version != XUCRED_VERSION) {
-		avahi_log_debug("credentials_version_check: unsupported version %d",
-				cred->cr_version);
-		return 0;
-	}
-	return 1;
+    if (cred->cr_version != XUCRED_VERSION) {
+        avahi_log_debug("credentials_version_check: unsupported version %d",
+                        cred->cr_version);
+        return 0;
+    }
+    return 1;
 }
 
 static uid_t credentials_getuid(const AvahiCred *cred) {
-	if (!credentials_version_check(cred))
-		return 0;
-	return cred->cr_uid;
+    if (!credentials_version_check(cred))
+        return (uid_t)-1;
+    return cred->cr_uid;
 }
 
 static gid_t credentials_getgid(const AvahiCred *cred) {
-	if (!credentials_version_check(cred) || cred->cr_ngroups <= 0)
-		return 0;
-	return cred->cr_groups[0];
+    if (!credentials_version_check(cred) || cred->cr_ngroups <= 0)
+        return 0;
+    return cred->cr_groups[0];
 }
 
 static pid_t credentials_getpid(const AvahiCred *cred) {
-	if (!credentials_version_check(cred))
-		return 0;
-	return cred->cr_pid;
+    if (!credentials_version_check(cred))
+        return 0;
+    return cred->cr_pid;
 }
 
 static int credentials_getsockopt(int fd, AvahiCred *cred, socklen_t *len) {
     *len = sizeof(*cred);
-    memset(cred, 0, sizeof(*cred));
-    return getsockopt(fd, SOL_LOCAL, LOCAL_PEERCRED, cred, len);
+    if (getsockopt(fd, SOL_LOCAL, LOCAL_PEERCRED, cred, len) != 0)
+        return -1;
+    if (*len != sizeof(*cred)) {
+        avahi_log_error("credentials_getsockopt: unexpected credential size %u (expected %zu)",
+                        (unsigned)*len, sizeof(*cred));
+        return -1;
+    }
+    return 0;
 }
 
-#  define CRED_FMT     "uid=%lu gid=%lu pid=%lu"
-#  define CRED_VALS(ucred) (long)credentials_getuid(ucred), (long)credentials_getgid(ucred), (long)credentials_getpid(ucred)
+#  define CRED_FMT     "uid=%lu gid=%lu pid=%ld"
+#  define CRED_ARGS(ucred) , (unsigned long)credentials_getuid(ucred), (unsigned long)credentials_getgid(ucred), (long)credentials_getpid(ucred)
 
 #else
-/* No support */
-#  define CRED_FMT     "%s"
-#  define CRED_VALS(ucred) ucred
+/* No credential retrieval support on this platform */
+#  define CRED_FMT     ""
+#  define CRED_ARGS(ucred)
 typedef unsigned char AvahiCred; /* need known type size. */
 
-static uid_t credentials_getuid(const AvahiCred *cred) {
-	(void)cred; return 0; /* no support for getting remote user. */
+/* Returns (uid_t)-1 to indicate that the UID is unknown, preventing the
+ * unknown-UID from being silently treated as root (uid 0). */
+static uid_t credentials_getuid(AVAHI_GCC_UNUSED const AvahiCred *cred) {
+    return (uid_t)-1;
 }
 
-static int credentials_getsockopt(int fd, AvahiCred *cred, socklen_t *len) {
-	(void)fd; *len = sizeof(*cred); *cred = 0;
-	return 0;
+static int credentials_getsockopt(AVAHI_GCC_UNUSED int fd, AvahiCred *cred, socklen_t *len) {
+    *len = sizeof(*cred);
+    *cred = 0;
+    return 0;
 }
 #endif
 
@@ -212,7 +226,7 @@ static void client_free(Client *c) {
     c->server->poll_api->watch_free(c->watch);
     close(c->fd);
     avahi_log_debug("simple client %d finished: " CRED_FMT,
-                    c->fd, CRED_VALS(&c->credentials));
+                    c->fd CRED_ARGS(&c->credentials));
 
     AVAHI_LLIST_REMOVE(Client, clients, c->server->clients, c);
     avahi_free(c);
@@ -359,10 +373,10 @@ static void dns_server_browser_callback(
 static void log_request(const Client *c, const char *cmd, const char *arg) {
     if (arg != NULL)
         avahi_log_debug(__FILE__": Got %s request for '%s'. " CRED_FMT,
-                        cmd, arg, CRED_VALS(&c->credentials));
+                        cmd, arg CRED_ARGS(&c->credentials));
     else
         avahi_log_debug(__FILE__": Got %s request. " CRED_FMT,
-                        cmd, CRED_VALS(&c->credentials));
+                        cmd CRED_ARGS(&c->credentials));
 }
 
 static void handle_line(Client *c, const char *s) {
@@ -541,36 +555,44 @@ static int is_client_allowed(Server *s, int cfd, AvahiCred *cred) {
 
     n_clients = s->n_clients + 1;
     if (credentials_getsockopt(cfd, cred, &len) != 0) {
-        avahi_log_error("credentials_getsockopt(%d): %s", cfd, strerror(errno));
+        avahi_log_error("Failed to get peer credentials for fd %d: %s", cfd, strerror(errno));
         return 0;
     }
 
     if (n_clients > s->max_clients) {
         avahi_log_debug("simple client %d refused: "CRED_FMT" too many clients",
-                        cfd, CRED_VALS(cred));
+                        cfd CRED_ARGS(cred));
         return 0;
     }
 
     uid = credentials_getuid(cred);
+    /* Per-UID limit applies to all non-root UIDs. (uid_t)-1 means the UID
+     * is unknown (no credential support on this platform); unknown UIDs are
+     * treated as non-root so they cannot bypass the per-UID limit.
+     *
+     * On platforms without credential support, all connections share one
+     * "unknown UID" bucket, which effectively limits them to max_uid_clients
+     * instead of max_clients. This is an acceptable tradeoff: returning 0
+     * (root) would silently skip per-UID enforcement entirely. */
     if (uid != 0 && n_clients > s->max_uid_clients) {
-        // There is enough clients to reach limit for one UID.
-        // Check this UID does not have too many requests already.
+        /* There are enough clients to reach the limit for one UID.
+         * Check this UID does not have too many connections already. */
         Client *c;
         unsigned present = 0;
 
         for (c = s->clients; c; c = c->clients_next) {
             if (credentials_getuid(&c->credentials) == uid) {
                 present++;
-                if (present > s->max_uid_clients) {
+                if (present >= s->max_uid_clients) {
                     avahi_log_debug("simple client %d refused: "CRED_FMT" too many uid clients: %u",
-                                    cfd, CRED_VALS(cred), present);
+                                    cfd CRED_ARGS(cred), present);
                     return 0;
                 }
             }
         }
     }
     avahi_log_debug("simple client %d/%u accepted: "CRED_FMT,
-                    cfd, n_clients, CRED_VALS(cred));
+                    cfd, n_clients CRED_ARGS(cred));
     return 1;
 }
 
@@ -585,7 +607,7 @@ static void server_work(AVAHI_GCC_UNUSED AvahiWatch *watch, int fd, AvahiWatchEv
         if ((cfd = accept(fd, NULL, NULL)) < 0) {
             if (errno != EMFILE && errno != ENFILE)
                 avahi_log_error(__FILE__" accept(): %s", strerror(errno));
-            else // Avoid client ability to flood log with too many requests
+            else /* Avoid giving clients the ability to flood the log with too many requests */
                 avahi_log_debug(__FILE__" accept(): %s", strerror(errno));
         } else {
             AvahiCred cred;

--- a/avahi-daemon/simple-protocol.c
+++ b/avahi-daemon/simple-protocol.c
@@ -45,6 +45,7 @@
 #include <avahi-common/malloc.h>
 #include <avahi-common/error.h>
 
+#include <avahi-core/hashmap.h>
 #include <avahi-core/log.h>
 #include <avahi-core/lookup.h>
 #include <avahi-core/dns-srv-rr.h>
@@ -224,6 +225,7 @@ struct Server {
     unsigned n_clients;
     unsigned max_clients;     /*< Maximal number of all simple clients. */
     unsigned max_uid_clients; /*< Maximal number of clients of one UID. */
+    AvahiHashmap *uid_clients; /*< UID -> UidClients, see uid_clients_ref(). */
     int remove_socket;
 };
 
@@ -231,11 +233,83 @@ static Server *server = NULL;
 
 static void client_work(AvahiWatch *watch, int fd, AvahiWatchEvent events, void *userdata);
 
+typedef struct UidClients {
+    uid_t uid;
+    unsigned n;
+} UidClients;
+
+static unsigned uid_hash(const void *data) {
+    const uid_t *uid = data;
+
+    assert(uid);
+
+    return (unsigned) *uid;
+}
+
+static int uid_equal(const void *a, const void *b) {
+    const uid_t *_a = a, *_b = b;
+
+    assert(_a);
+    assert(_b);
+
+    return *_a == *_b;
+}
+
+static unsigned uid_clients_count(Server *s, uid_t uid) {
+    UidClients *u;
+
+    assert(s);
+
+    if (!(u = avahi_hashmap_lookup(s->uid_clients, &uid)))
+        return 0;
+
+    return u->n;
+}
+
+static int uid_clients_ref(Server *s, uid_t uid) {
+    UidClients *u;
+
+    assert(s);
+
+    if ((u = avahi_hashmap_lookup(s->uid_clients, &uid))) {
+        u->n++;
+        return 0;
+    }
+
+    if (!(u = avahi_new(UidClients, 1)))
+        return -1;
+
+    u->uid = uid;
+    u->n = 1;
+
+    if (avahi_hashmap_insert(s->uid_clients, &u->uid, u) < 0) {
+        avahi_free(u);
+        return -1;
+    }
+
+    return 0;
+}
+
+static void uid_clients_unref(Server *s, uid_t uid) {
+    UidClients *u;
+
+    assert(s);
+
+    if (!(u = avahi_hashmap_lookup(s->uid_clients, &uid)))
+        return;
+
+    assert(u->n >= 1);
+
+    if (--u->n == 0)
+        avahi_hashmap_remove(s->uid_clients, &uid);
+}
+
 static void client_free(Client *c) {
     assert(c);
 
     assert(c->server->n_clients >= 1);
     c->server->n_clients--;
+    uid_clients_unref(c->server, credentials_getuid(&c->credentials));
 
     if (c->host_name_resolver)
         avahi_s_host_name_resolver_free(c->host_name_resolver);
@@ -255,12 +329,19 @@ static void client_free(Client *c) {
     avahi_free(c);
 }
 
-static void client_new(Server *s, int fd, const AvahiCred *cred) {
+static int client_new(Server *s, int fd, const AvahiCred *cred) {
     Client *c;
 
     assert(fd >= 0);
 
-    c = avahi_new(Client, 1);
+    if (!(c = avahi_new(Client, 1)))
+        return -1;
+
+    if (uid_clients_ref(s, credentials_getuid(cred)) < 0) {
+        avahi_free(c);
+        return -1;
+    }
+
     c->server = s;
     c->fd = fd;
     c->state = CLIENT_IDLE;
@@ -276,6 +357,8 @@ static void client_new(Server *s, int fd, const AvahiCred *cred) {
 
     AVAHI_LLIST_PREPEND(Client, clients, s->clients, c);
     s->n_clients++;
+
+    return 0;
 }
 
 static void client_output(Client *c, const uint8_t*data, size_t size) {
@@ -597,22 +680,10 @@ static int is_client_allowed(Server *s, int cfd, AvahiCred *cred) {
      * "unknown UID" bucket, which effectively limits them to max_uid_clients
      * instead of max_clients. This is an acceptable tradeoff: returning 0
      * (root) would silently skip per-UID enforcement entirely. */
-    if (uid != 0 && n_clients >= s->max_uid_clients) {
-        /* There are enough clients to reach the limit for one UID.
-         * Check this UID does not have too many connections already. */
-        Client *c;
-        unsigned present = 0;
-
-        for (c = s->clients; c; c = c->clients_next) {
-            if (credentials_getuid(&c->credentials) == uid) {
-                present++;
-                if (present >= s->max_uid_clients) {
-                    avahi_log_debug("simple client %d refused: "CRED_FMT" too many uid clients: %u",
-                                    cfd CRED_ARGS(cred), present);
-                    return 0;
-                }
-            }
-        }
+    if (uid != 0 && uid_clients_count(s, uid) >= s->max_uid_clients) {
+        avahi_log_debug("simple client %d refused: "CRED_FMT" too many uid clients: %u",
+                        cfd CRED_ARGS(cred), s->max_uid_clients);
+        return 0;
     }
     avahi_log_debug("simple client %d/%u accepted: "CRED_FMT,
                     cfd, n_clients CRED_ARGS(cred));
@@ -634,9 +705,11 @@ static void server_work(AVAHI_GCC_UNUSED AvahiWatch *watch, int fd, AvahiWatchEv
                 avahi_log_debug(__FILE__" accept(): %s", strerror(errno));
         } else {
             AvahiCred cred;
-            if (is_client_allowed(s, cfd, &cred))
-                client_new(s, cfd, &cred);
-            else {
+            if (!is_client_allowed(s, cfd, &cred))
+                close(cfd);
+            else if (client_new(s, cfd, &cred) < 0) {
+                /* debug level to not flood the log */
+                avahi_log_debug(__FILE__" client_new(): out of memory");
                 close(cfd);
             }
         }
@@ -664,8 +737,14 @@ int simple_protocol_setup(const AvahiPoll *poll_api, unsigned max_clients) {
         server->max_uid_clients = 1;
     AVAHI_LLIST_HEAD_INIT(Client, server->clients);
     server->watch = NULL;
+    server->uid_clients = NULL;
 
     u = umask(0000);
+
+    if (!(server->uid_clients = avahi_hashmap_new(uid_hash, uid_equal, NULL, avahi_free))) {
+        avahi_log_warn("avahi_hashmap_new(): Out of memory");
+        goto fail;
+    }
 
 #ifdef HAVE_LIBSYSTEMD
     if ((n = sd_listen_fds(1)) < 0) {
@@ -757,6 +836,9 @@ void simple_protocol_shutdown(void) {
 
         if (server->fd >= 0)
             close(server->fd);
+
+        if (server->uid_clients)
+            avahi_hashmap_free(server->uid_clients);
 
         avahi_free(server);
 

--- a/avahi-daemon/simple-protocol.c
+++ b/avahi-daemon/simple-protocol.c
@@ -35,8 +35,9 @@
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>
 #endif
-#ifdef HAVE_STRUCT_XUCRED
-#include <sys/ucred.h>
+
+#ifdef HAVE_UCRED_H
+#include <ucred.h>
 #endif
 
 #include <avahi-common/domain.h>
@@ -85,7 +86,7 @@ static int credentials_getsockopt(int fd, AvahiCred *cred, socklen_t *len) {
     if (getsockopt(fd, SOL_SOCKET, SO_PEERCRED, cred, len) != 0)
         return -1;
     if (*len != sizeof(*cred)) {
-        avahi_log_error("credentials_getsockopt: unexpected credential size %u (expected %zu)",
+        avahi_log_debug("credentials_getsockopt: unexpected credential size %u (expected %zu)",
                         (unsigned)*len, sizeof(*cred));
         return -1;
     }
@@ -95,51 +96,73 @@ static int credentials_getsockopt(int fd, AvahiCred *cred, socklen_t *len) {
 #  define CRED_FMT     "uid=%lu gid=%lu pid=%ld"
 #  define CRED_ARGS(ucred) , (unsigned long)credentials_getuid(ucred), (unsigned long)credentials_getgid(ucred), (long)credentials_getpid(ucred)
 
-#elif defined(HAVE_STRUCT_XUCRED) && defined(XUCRED_VERSION)
-/* FreeBSD support, man 4 unix */
-typedef struct xucred AvahiCred;
-
-static int credentials_version_check(const AvahiCred *cred) {
-    if (cred->cr_version != XUCRED_VERSION) {
-        avahi_log_debug("credentials_version_check: unsupported version %d",
-                        cred->cr_version);
-        return 0;
-    }
-    return 1;
-}
+#elif defined(HAVE_GETPEEREID)
+/* BSD support by getpeereid */
+typedef struct AvahiCred {
+    uid_t uid;
+    gid_t gid;
+} AvahiCred;
 
 static uid_t credentials_getuid(const AvahiCred *cred) {
-    if (!credentials_version_check(cred))
-        return (uid_t)-1;
-    return cred->cr_uid;
+    return cred->uid;
 }
 
 static gid_t credentials_getgid(const AvahiCred *cred) {
-    if (!credentials_version_check(cred) || cred->cr_ngroups <= 0)
-        return 0;
-    return cred->cr_groups[0];
-}
-
-static pid_t credentials_getpid(const AvahiCred *cred) {
-    if (!credentials_version_check(cred))
-        return 0;
-    return cred->cr_pid;
+    return cred->gid;
 }
 
 static int credentials_getsockopt(int fd, AvahiCred *cred, socklen_t *len) {
     *len = sizeof(*cred);
-    if (getsockopt(fd, SOL_LOCAL, LOCAL_PEERCRED, cred, len) != 0)
+    return getpeereid(fd, &cred->uid, &cred->gid);
+}
+
+#  define CRED_FMT     "uid=%lu gid=%lu"
+#  define CRED_ARGS(cred) , (unsigned long)credentials_getuid(cred), (unsigned long)credentials_getgid(cred)
+
+#elif defined(HAVE_GETPEERUCRED)
+/* illumos/Solaris support by getpeerucred(3C). */
+typedef struct AvahiCred {
+    uid_t uid;
+    gid_t gid;
+    pid_t pid;
+} AvahiCred;
+
+static uid_t credentials_getuid(const AvahiCred *cred) {
+    return cred->uid;
+}
+
+static gid_t credentials_getgid(const AvahiCred *cred) {
+    return cred->gid;
+}
+
+static pid_t credentials_getpid(const AvahiCred *cred) {
+    return cred->pid;
+}
+
+static int credentials_getsockopt(int fd, AvahiCred *cred, socklen_t *len) {
+    ucred_t *uc = NULL;
+
+    *len = sizeof(*cred);
+
+    if (getpeerucred(fd, &uc) != 0)
         return -1;
-    if (*len != sizeof(*cred)) {
-        avahi_log_error("credentials_getsockopt: unexpected credential size %u (expected %zu)",
-                        (unsigned)*len, sizeof(*cred));
+
+    cred->uid = ucred_geteuid(uc);
+    cred->gid = ucred_getegid(uc);
+    cred->pid = ucred_getpid(uc);
+    ucred_free(uc);
+
+    /* if ucred_geteuid() (uid_t)-1 it means unknown UID, refuse the connection */
+    if (cred->uid == (uid_t)-1) {
+        errno = ENOTSUP;
         return -1;
     }
+
     return 0;
 }
 
 #  define CRED_FMT     "uid=%lu gid=%lu pid=%ld"
-#  define CRED_ARGS(ucred) , (unsigned long)credentials_getuid(ucred), (unsigned long)credentials_getgid(ucred), (long)credentials_getpid(ucred)
+#  define CRED_ARGS(cred) , (unsigned long)credentials_getuid(cred), (unsigned long)credentials_getgid(cred), (long)credentials_getpid(cred)
 
 #else
 /* No credential retrieval support on this platform */
@@ -554,14 +577,14 @@ static int is_client_allowed(Server *s, int cfd, AvahiCred *cred) {
     assert(s != NULL);
 
     n_clients = s->n_clients + 1;
-    if (credentials_getsockopt(cfd, cred, &len) != 0) {
-        avahi_log_error("Failed to get peer credentials for fd %d: %s", cfd, strerror(errno));
+    if (n_clients > s->max_clients) {
+        /* Debug so it will not flood the log. */
+        avahi_log_debug("simple client %d refused: too many clients", cfd);
         return 0;
     }
 
-    if (n_clients > s->max_clients) {
-        avahi_log_debug("simple client %d refused: "CRED_FMT" too many clients",
-                        cfd CRED_ARGS(cred));
+    if (credentials_getsockopt(cfd, cred, &len) != 0) {
+        avahi_log_debug("Failed to get peer credentials for fd %d: %s", cfd, strerror(errno));
         return 0;
     }
 
@@ -635,7 +658,10 @@ int simple_protocol_setup(const AvahiPoll *poll_api, unsigned max_clients) {
     server->fd = -1;
     server->n_clients = 0;
     server->max_clients = max_clients;
-    server->max_uid_clients = max_clients / 2;
+    /* A single non-root UID may hold at most a quarter of the total */
+    server->max_uid_clients = max_clients / 4;
+    if (server->max_uid_clients < 1)
+        server->max_uid_clients = 1;
     AVAHI_LLIST_HEAD_INIT(Client, server->clients);
     server->watch = NULL;
 
@@ -698,8 +724,9 @@ int simple_protocol_setup(const AvahiPoll *poll_api, unsigned max_clients) {
     umask(u);
 
     server->watch = poll_api->watch_new(poll_api, server->fd, AVAHI_WATCH_IN, server_work, server);
-    avahi_log_info("Maximal simple clients: %u, per_uid: %u",
-                    max_clients, server->max_uid_clients);
+    /* Notice so OpenBSD stock syslog will not drop this message */
+    avahi_log_notice("Maximal simple clients: %u, per_uid: %u",
+                     max_clients, server->max_uid_clients);
 
     return 0;
 

--- a/avahi-daemon/simple-protocol.h
+++ b/avahi-daemon/simple-protocol.h
@@ -22,7 +22,10 @@
 
 #include <avahi-common/watch.h>
 
-int simple_protocol_setup(const AvahiPoll *poll_api);
+/* max_clients is number of concurrent simple mdns clients allowed.
+ * When limit is reached, new clients are immediately closed.
+ * Per UID limit is derived from this number. */
+int simple_protocol_setup(const AvahiPoll *poll_api, unsigned max_clients);
 void simple_protocol_shutdown(void);
 void simple_protocol_restart_queries(void);
 

--- a/configure.ac
+++ b/configure.ac
@@ -222,6 +222,21 @@ if test $avahi_cv_has_struct_lifconf = yes; then
 fi
 
 #
+# Check for xucred struct; only present on FreeBSD
+#
+AC_MSG_CHECKING(for struct xucred)
+AC_CACHE_VAL(avahi_cv_has_struct_xucred,
+[AC_TRY_COMPILE(
+[#include <sys/socket.h>
+#include <sys/ucred.h>
+],[sizeof (struct xucred);],
+avahi_cv_has_struct_xucred=yes,avahi_cv_has_struct_xucred=no)])
+AC_MSG_RESULT($avahi_cv_has_struct_xucred)
+if test $avahi_cv_has_struct_xucred = yes; then
+    AC_DEFINE(HAVE_STRUCT_XUCRED,1,[Define if there is a struct xucred.])
+fi
+
+#
 # Check for struct ip_mreqn
 #
 AC_MSG_CHECKING(for struct ip_mreqn)

--- a/configure.ac
+++ b/configure.ac
@@ -222,21 +222,6 @@ if test $avahi_cv_has_struct_lifconf = yes; then
 fi
 
 #
-# Check for xucred struct; only present on FreeBSD
-#
-AC_MSG_CHECKING(for struct xucred)
-AC_CACHE_VAL(avahi_cv_has_struct_xucred,
-[AC_TRY_COMPILE(
-[#include <sys/socket.h>
-#include <sys/ucred.h>
-],[sizeof (struct xucred);],
-avahi_cv_has_struct_xucred=yes,avahi_cv_has_struct_xucred=no)])
-AC_MSG_RESULT($avahi_cv_has_struct_xucred)
-if test $avahi_cv_has_struct_xucred = yes; then
-    AC_DEFINE(HAVE_STRUCT_XUCRED,1,[Define if there is a struct xucred.])
-fi
-
-#
 # Check for struct ip_mreqn
 #
 AC_MSG_CHECKING(for struct ip_mreqn)
@@ -382,8 +367,8 @@ AC_FUNC_SELECT_ARGTYPES
 # whether libc's malloc does too. (Same for realloc.)
 #AC_FUNC_MALLOC
 #AC_FUNC_REALLOC
-AC_CHECK_FUNCS([gethostname memchr memmove memset mkdir select socket strchr strcspn strdup strerror strrchr strspn strstr uname setresuid setreuid setresgid setregid strcasecmp gettimeofday putenv strncasecmp strlcpy gethostbyname seteuid setegid setproctitle getprogname getrandom])
-AC_CHECK_HEADERS([sys/random.h])
+AC_CHECK_FUNCS([gethostname memchr memmove memset mkdir select socket strchr strcspn strdup strerror strrchr strspn strstr uname setresuid setreuid setresgid setregid strcasecmp gettimeofday putenv strncasecmp strlcpy gethostbyname seteuid setegid setproctitle getprogname getrandom getpeereid getpeerucred])
+AC_CHECK_HEADERS([sys/random.h ucred.h])
 
 AC_FUNC_CHOWN
 AC_FUNC_STAT

--- a/man/avahi-daemon.conf.5.xml.in
+++ b/man/avahi-daemon.conf.5.xml.in
@@ -369,7 +369,14 @@
     </option>
 
     <option>
-      <p><opt>rlimit-nofile=</opt> Value for RLIMIT_NOFILE (open file descriptors). avahi-daemon shouldn't need more than 15 to 20 open file descriptors concurrently.</p>
+      <p><opt>rlimit-nofile=</opt> Value for RLIMIT_NOFILE (open file
+      descriptors). avahi-daemon needs 15 to 20 descriptors for its own
+      use, but this setting also sizes the client limit of the simple
+      protocol Unix socket: half of the effective limit, capped at 4096,
+      may be occupied by concurrent clients, and any single non-root user
+      may hold at most a quarter of that. Setting this very low therefore
+      restricts concurrent .local name resolution through nss-mdns rather
+      than merely capping descriptor usage.</p>
     </option>
 
     <option>


### PR DESCRIPTION
Used work from #808 and #895
Main changes was to use getpeereid() instead of xucred as it more generic and used on more platforms. Also work was done to slightly refactor smoke test so it will be stable.
Commits was assisted by AI but reviewed and rewritten by me.