### PR TITLE
ci: dump_journal from the host log backend, not WITH_SYSTEMD

### DIFF
--- a/.github/workflows/smoke-tests.sh
+++ b/.github/workflows/smoke-tests.sh
@@ -40,12 +40,25 @@ avahi_socket="$avahi_daemon_runtime_dir/socket"
 valgrind_log_file="/tmp/valgrind.avahi-daemon.%p"
 
 dump_journal() {
-    if [[ "$WITH_SYSTEMD" == false ]]; then
-        cat /var/adm/messages || true
-        cat /var/log/messages
+    local log_file
+
+    if command -v journalctl >/dev/null 2>&1 && journalctl --sync 2>/dev/null; then
+        if [[ "$WITH_SYSTEMD" == true ]]; then
+            journalctl -b -u "avahi-*" --no-pager
+        else
+            journalctl -b -t avahi-daemon --no-pager
+        fi
     else
-        journalctl --sync
-        journalctl -b -u "avahi-*" --no-pager
+        for log_file in \
+            /var/log/syslog \
+            /var/log/messages \
+            /var/log/daemon \
+            /var/log/daemon.log \
+            /var/adm/messages; do
+            if [[ -r "$log_file" ]]; then
+                cat "$log_file"
+            fi
+        done
     fi
 }
 


### PR DESCRIPTION
A non-systemd build can still run under journald, and WITH_SYSTEMD does not tell us which files hold daemon.info. Prefer journalctl when it works, then read every common syslog file so OpenBSD, FreeBSD, and OmniOS dumps are not empty.

GHActions: https://github.com/nokia/avahi/actions/runs/34099081639
#975 